### PR TITLE
Reverted to using twitter advanced search endpoint for fetching tweets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.17.13",
-		"@types/express-graphql": "0.9.0",
 		"@types/graphql": "14.5.0",
 		"@types/node": "17.0.24",
 		"nodemon": "2.0.20",

--- a/src/models/graphql/UserTypes.ts
+++ b/src/models/graphql/UserTypes.ts
@@ -4,6 +4,7 @@ import { GraphQLBoolean, GraphQLObjectType, GraphQLString, GraphQLInt, GraphQLLi
 // TYPES
 import { Tweet, TweetList } from './TweetTypes'
 import { Cursor } from './Global';
+import { TweetFilter } from '../../types/Tweet';
 
 // RESOLVERS
 import UserResolver from '../../resolvers/UserResolver';
@@ -113,7 +114,7 @@ export const User = new GraphQLObjectType({
                     defaultValue: ''
                 }
             },
-            resolve: (parent, args, context) => new UserResolver(context).resolveUserTweets(parent.id, args.count, args.all, args.cursor, parent.statusesCount)
+            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets({ fromUsers: [parent.userName], count: args.count } as TweetFilter, args.cursor)
         }
     })
 });

--- a/src/models/graphql/UserTypes.ts
+++ b/src/models/graphql/UserTypes.ts
@@ -114,7 +114,7 @@ export const User = new GraphQLObjectType({
                     defaultValue: ''
                 }
             },
-            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets({ fromUsers: [parent.userName], count: args.count } as TweetFilter, args.cursor)
+            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets({ fromUsers: [parent.userName] } as TweetFilter, args.count, args.cursor)
         }
     })
 });

--- a/src/queries/RootQuery.ts
+++ b/src/queries/RootQuery.ts
@@ -32,11 +32,7 @@ export const rootQuery = new GraphQLObjectType({
                 id: { type: GraphQLString }
             },
             resolve: (parent, args, context) => new TweetResolver(context).resolveTweet(args.id)
-        }
-        /**
-         * Disabled because twitter advanced search reverse engineering is broken right now.
-         * Use user tweets instead
-         * 
+        },
         Tweets: {
             type: TweetList,
             description: "Returns the list of tweets matching the given criteria",
@@ -54,6 +50,5 @@ export const rootQuery = new GraphQLObjectType({
             },
             resolve: (parent, args, context) => new TweetResolver(context).resolveTweets(args)
         }
-        */
     }
 })

--- a/src/queries/RootQuery.ts
+++ b/src/queries/RootQuery.ts
@@ -4,6 +4,7 @@ import { GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLString } from 'graph
 // TYPES
 import { User } from '../models/graphql/UserTypes';
 import { Tweet, TweetList } from '../models/graphql/TweetTypes';
+import { TweetFilter } from '../types/Tweet';
 
 // RESOLVERS
 import UserResolver from '../resolvers/UserResolver';
@@ -48,7 +49,7 @@ export const rootQuery = new GraphQLObjectType({
                 count: { type: GraphQLInt, defaultValue: 20 },
                 cursor: { type: GraphQLString, defaultValue: '' }
             },
-            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets(args)
+            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets(args as TweetFilter, args.cursor)
         }
     }
 })

--- a/src/queries/RootQuery.ts
+++ b/src/queries/RootQuery.ts
@@ -49,7 +49,7 @@ export const rootQuery = new GraphQLObjectType({
                 count: { type: GraphQLInt, defaultValue: 20 },
                 cursor: { type: GraphQLString, defaultValue: '' }
             },
-            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets(args as TweetFilter, args.cursor)
+            resolve: (parent, args, context) => new TweetResolver(context).resolveTweets(args as TweetFilter, args.count, args.cursor)
         }
     }
 })

--- a/src/resolvers/TweetResolver.ts
+++ b/src/resolvers/TweetResolver.ts
@@ -85,13 +85,7 @@ export default class TweetResolver extends ResolverBase {
      * @param cursor The cursor to the batch of tweet quotes to fetch
      * @param quoteCount The total number of quotes of the given tweet
      */
-    async resolveTweetQuotes(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        quoteCount: number
-    ): Promise<any[]> {
+    async resolveTweetQuotes(id: string, count: number, all: boolean, cursor: string, quoteCount: number): Promise<any[]> {
         let quotes: any[] = [];                                                     // To store the list of quotes
 
         // If all tweets are to be fetched
@@ -123,13 +117,7 @@ export default class TweetResolver extends ResolverBase {
      * @param cursor The cursor to the batch of likers to fetch
      * @param likesCount The total number of like of the tweet
      */
-    async resolveTweetLikers(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        likesCount: number
-    ): Promise<any[]> {
+    async resolveTweetLikers(id: string, count: number, all: boolean, cursor: string, likesCount: number): Promise<any[]> {
         let likers: any[] = [];                                                     // To store the list of likers
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of likers fetched
@@ -180,13 +168,7 @@ export default class TweetResolver extends ResolverBase {
      * @param cursor The cursor to the batch of retweeters to fetch
      * @param retweetsCount The total number of retweets of the 
      */
-    async resolveTweetRetweeters(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        retweetsCount: number
-    ): Promise<any[]> {
+    async resolveTweetRetweeters(id: string, count: number, all: boolean, cursor: string, retweetsCount: number): Promise<any[]> {
         let retweeters: any[] = [];                                                 // To store the list of retweeters
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of retweeters fetched
@@ -237,13 +219,7 @@ export default class TweetResolver extends ResolverBase {
      * @param cursor The cursor to the batch of replies to fetch
      * @param repliesCount The total number of replies to the target tweet
      */
-    async resolveTweetReplies(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        repliesCount: number
-    ): Promise<any[]> {
+    async resolveTweetReplies(id: string, count: number, all: boolean, cursor: string, repliesCount: number): Promise<any[]> {
         let replies: any[] = [];                                                    // To store the list of replies
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of replies fetched

--- a/src/resolvers/TweetResolver.ts
+++ b/src/resolvers/TweetResolver.ts
@@ -29,15 +29,13 @@ export default class TweetResolver extends ResolverBase {
     /**
      * @returns The list of tweets matching the given filter
      * @param filter The filter to be used for fetching matching tweets
+     * @param cursor The cursor to the batch of tweets to fetch
      */
-    async resolveTweets(filter: any): Promise<any[]> {
+    async resolveTweets(filter: TweetFilter, cursor: string): Promise<any[]> {
         let tweets: any[] = [];                                                     // To store the list of tweets
-        let next: Cursor = new Cursor(filter.cursor);                               // To store cursor to next batch
+        let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of tweets fetched
         let batchSize: number = 20;                                                 // To store the batchsize to use
-
-        // Preparing the filter to use
-        const tweetFilter: TweetFilter = filter;
 
         // Checking if the given tweet filter is valid or not
         if (!(filter.fromUsers || filter.toUsers || filter.words || filter.hashtags || filter.mentions || filter.quoted)) {
@@ -45,15 +43,15 @@ export default class TweetResolver extends ResolverBase {
         }
 
         // If required count less than batch size, setting batch size to required count
-        batchSize = (tweetFilter.count < batchSize) ? tweetFilter.count : batchSize;
+        batchSize = (filter.count < batchSize) ? filter.count : batchSize;
 
         // Repeatedly fetching data as long as total data fetched is less than requried
-        while (total < tweetFilter.count) {
+        while (total < filter.count) {
             // If this is the last batch, change batch size to number of remaining tweets
-            batchSize = ((tweetFilter.count - total) < batchSize) ? (tweetFilter.count - total) : batchSize;
+            batchSize = ((filter.count - total) < batchSize) ? (filter.count - total) : batchSize;
 
             // Getting the data
-            const res = await this.context.tweets.getTweets(tweetFilter, next.value);
+            const res = await this.context.tweets.getTweets(filter, next.value);
 
             // If data is available
             if (res.list.length) {
@@ -108,12 +106,11 @@ export default class TweetResolver extends ResolverBase {
             startDate: '',
             endDate: '',
             quoted: id,
-            count: count,
-            cursor: cursor
+            count: count
         };
 
         // Fetching the quotes using resolveTweets method
-        quotes = await this.resolveTweets(filter);
+        quotes = await this.resolveTweets(filter, cursor);
 
         return quotes;
     }

--- a/src/resolvers/TweetResolver.ts
+++ b/src/resolvers/TweetResolver.ts
@@ -29,9 +29,10 @@ export default class TweetResolver extends ResolverBase {
     /**
      * @returns The list of tweets matching the given filter
      * @param filter The filter to be used for fetching matching tweets
+     * @param count The number of tweets to fetch
      * @param cursor The cursor to the batch of tweets to fetch
      */
-    async resolveTweets(filter: TweetFilter, cursor: string): Promise<any[]> {
+    async resolveTweets(filter: TweetFilter, count: number, cursor: string): Promise<any[]> {
         let tweets: any[] = [];                                                     // To store the list of tweets
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of tweets fetched
@@ -43,15 +44,15 @@ export default class TweetResolver extends ResolverBase {
         }
 
         // If required count less than batch size, setting batch size to required count
-        batchSize = (filter.count < batchSize) ? filter.count : batchSize;
+        batchSize = (count < batchSize) ? count : batchSize;
 
         // Repeatedly fetching data as long as total data fetched is less than requried
-        while (total < filter.count) {
+        while (total < count) {
             // If this is the last batch, change batch size to number of remaining tweets
-            batchSize = ((filter.count - total) < batchSize) ? (filter.count - total) : batchSize;
+            batchSize = ((count - total) < batchSize) ? (count - total) : batchSize;
 
             // Getting the data
-            const res = await this.context.tweets.getTweets(filter, next.value);
+            const res = await this.context.tweets.getTweets(filter, count, next.value);
 
             // If data is available
             if (res.list.length) {
@@ -105,12 +106,11 @@ export default class TweetResolver extends ResolverBase {
             mentions: [],
             startDate: '',
             endDate: '',
-            quoted: id,
-            count: count
+            quoted: id
         };
 
         // Fetching the quotes using resolveTweets method
-        quotes = await this.resolveTweets(filter, cursor);
+        quotes = await this.resolveTweets(filter, count, cursor);
 
         return quotes;
     }

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -41,13 +41,7 @@ export default class UserResolver extends ResolverBase {
      * @param cursor The cursor to the batch of likes to fetch
      * @param favouritesCount The total number of tweets liked by target user
      */
-    async resolveUserLikes(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        favouritesCount: number
-    ): Promise<any> {
+    async resolveUserLikes(id: string, count: number, all: boolean, cursor: string, favouritesCount: number): Promise<any> {
         let likes: any[] = [];                                                      // To store the list of liked tweets
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of liked twets fetched
@@ -98,13 +92,7 @@ export default class UserResolver extends ResolverBase {
      * @param cursor The cursor to the batch of followers to fetch
      * @param followerCount The total number of followers of the target user
      */
-    async resolveUserFollowers(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        followersCount: number
-    ): Promise<any> {
+    async resolveUserFollowers(id: string, count: number, all: boolean, cursor: string, followersCount: number): Promise<any> {
         let followers: any[] = [];                                                  // To store the list of followers
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of followers fetched
@@ -155,13 +143,7 @@ export default class UserResolver extends ResolverBase {
      * @param cursor The cursor to the batch of followings to fetch
      * @param followingsCount The total number of followings of the target user
      */
-    async resolveUserFollowing(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        followingsCount: number
-    ): Promise<any> {
+    async resolveUserFollowing(id: string, count: number, all: boolean, cursor: string, followingsCount: number): Promise<any> {
         let following: any[] = [];                                                  // To store the list of following
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of following fetched
@@ -212,13 +194,7 @@ export default class UserResolver extends ResolverBase {
      * @param cursor The cursor to the batch of tweets to fetch
      * @param statusesCount The total number of tweets made by target user
      */
-    async resolveUserTweets(
-        id: string,
-        count: number,
-        all: boolean,
-        cursor: string,
-        statusesCount: number
-    ): Promise<any> {
+    async resolveUserTweets(id: string, count: number, all: boolean, cursor: string, statusesCount: number): Promise<any> {
         let tweets: any[] = [];                                                     // To store the list of tweets
         let next: Cursor = new Cursor(cursor);                                      // To store cursor to next batch
         let total: number = 0;                                                      // To store the total number of tweets fetched

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -6,7 +6,7 @@ import { AuthService } from './AuthService';
 import { CacheService } from './CacheService';
 
 // TYPES
-import { HttpMethods, HttpStatus } from "../types/HTTP";
+import { HttpStatus } from "../types/HTTP";
 import { Result as RawUser } from '../types/raw/user/User';
 import { Result as RawTweet } from '../types/raw/tweet/Tweet';
 

--- a/src/services/data/TweetService.ts
+++ b/src/services/data/TweetService.ts
@@ -20,6 +20,9 @@ import * as Extractors from "../helper/Extractors";
 // DESERIALIZERS
 import * as Deserializers from '../helper/Deserializers';
 
+// PARSERS
+import { toQueryString } from '../helper/Parser';
+
 /**
  * A service that deals with fetching of data related to tweets
  */
@@ -30,26 +33,6 @@ export class TweetService extends FetcherService {
     }
 
     /**
-     * @param filter The tweet filter to use for getting filtered tweets
-     * @returns The same tweet filter, in a URL query format string
-     */
-    private toQueryString(filter: TweetFilter): string {
-        // Concatenating the input filter arguments to a URL query formatted string
-        return [
-            filter.words ? filter.words.join(' ') : '',
-            filter.hashtags ? `(${filter.hashtags.map(hashtag => '%23' + hashtag).join(' OR ')})` : '',
-            filter.fromUsers ? `(${filter.fromUsers.map(user => `from:${user}`).join(' OR ')})` : '',
-            filter.toUsers ? `(${filter.toUsers.map(user => `to:${user}`).join(' OR ')})` : '',
-            filter.mentions ? `(${filter.mentions.map(mention => '%40' + mention).join(' OR ')})` : '',
-            filter.startDate ? `since:${filter.startDate}` : '',
-            filter.endDate ? `until:${filter.endDate}` : '',
-            filter.quoted ? `quoted_tweet_id:${filter.quoted}` : ''
-        ]
-        .filter(item => item !== '()' && item !== '')
-        .join(' ');
-    }
-
-    /**
      * @returns The list of tweets that match the given filter
      * @param filter The filter be used for searching the tweets
      * @param count The number of tweets to fetch
@@ -57,7 +40,7 @@ export class TweetService extends FetcherService {
      */
     async getTweets(filter: TweetFilter, count: number, cursor: string): Promise<CursoredData<Tweet>> {
         // Getting the raw data
-        let res = await this.request<RawTweets>(Urls.tweetsUrl(this.toQueryString(filter), count, cursor)).then(res => res.data);
+        let res = await this.request<RawTweets>(Urls.tweetsUrl(toQueryString(filter), count, cursor)).then(res => res.data);
 
         // Extracting data
         let data = Extractors.extractTweets(res);

--- a/src/services/helper/Deserializers.ts
+++ b/src/services/helper/Deserializers.ts
@@ -84,7 +84,7 @@ export function toTweet(data: RawTweet): Tweet {
         tweetBy: data.legacy.user_id_str,
         entities: toTweetEntities(data.legacy.entities),
         quoted: data.legacy.quoted_status_id_str,
-        fullText: Parsers.normalizeText(data.legacy.full_text),
+        fullText: Parsers.normalizeText(data.legacy.text),
         replyTo: data.legacy.in_reply_to_status_id_str,
         lang: data.legacy.lang,
         quoteCount: data.legacy.quote_count,

--- a/src/services/helper/Parser.ts
+++ b/src/services/helper/Parser.ts
@@ -1,3 +1,5 @@
+import { TweetFilter } from '../../types/Tweet';
+
 /**
  * @returns Whether the given json object is empty or not
  * @param data The input JSON object which needs to be checked
@@ -83,4 +85,24 @@ export function normalizeText(text: string): string {
     normalizedText = normalizedText.endsWith('.') ? normalizedText : (normalizedText + '.');
 
     return normalizedText;
+}
+
+/**
+ * @param filter The tweet filter to use for getting filtered tweets
+ * @returns The same tweet filter, in a URL query format string
+ */
+export function toQueryString(filter: TweetFilter): string {
+    // Concatenating the input filter arguments to a URL query formatted string
+    return [
+        filter.words ? filter.words.join(' ') : '',
+        filter.hashtags ? `(${filter.hashtags.map(hashtag => '%23' + hashtag).join(' OR ')})` : '',
+        filter.fromUsers ? `(${filter.fromUsers.map(user => `from:${user}`).join(' OR ')})` : '',
+        filter.toUsers ? `(${filter.toUsers.map(user => `to:${user}`).join(' OR ')})` : '',
+        filter.mentions ? `(${filter.mentions.map(mention => '%40' + mention).join(' OR ')})` : '',
+        filter.startDate ? `since:${filter.startDate}` : '',
+        filter.endDate ? `until:${filter.endDate}` : '',
+        filter.quoted ? `quoted_tweet_id:${filter.quoted}` : ''
+    ]
+    .filter(item => item !== '()' && item !== '')
+    .join(' ');
 }

--- a/src/services/helper/Urls.ts
+++ b/src/services/helper/Urls.ts
@@ -79,16 +79,7 @@ export function tweetsUrl(filter: TweetFilter, cursor: string): string {
 
     let url = '';
 
-    // If a cursor has been supplied
-    if (cursor) {
-        url = `https://twitter.com/i/api/2/search/adaptive.json?include_profile_interstitial_type=1&include_blocking=1&include_blocked_by=1&include_followed_by=1&include_want_retweets=1&include_mute_edge=1&include_can_dm=1&include_can_media_tag=1&include_ext_has_nft_avatar=1&skip_status=1&cards_platform=Web-12&include_cards=1&include_ext_alt_text=true&include_quote_count=true&include_reply_count=1&tweet_mode=extended&include_entities=true&include_user_entities=true&include_ext_media_color=true&include_ext_media_availability=true&include_ext_sensitive_media_warning=true&send_error_codes=true&simple_quoted_tweet=true&q=${query}&tweet_search_mode=live&count=${filter.count}&query_source=typed_query&cursor=${cursor}&pc=1&spelling_corrections=1&ext=mediaStats%2ChighlightedLabel%2ChasNftAvatar%2CvoiceInfo%2CsuperFollowMetadata`
-    }
-    // If no cursor has been supplied
-    else {
-        url = `https://twitter.com/i/api/2/search/adaptive.json?include_profile_interstitial_type=1&include_blocking=1&include_blocked_by=1&include_followed_by=1&include_want_retweets=1&include_mute_edge=1&include_can_dm=1&include_can_media_tag=1&include_ext_has_nft_avatar=1&skip_status=1&cards_platform=Web-12&include_cards=1&include_ext_alt_text=true&include_quote_count=true&include_reply_count=1&tweet_mode=extended&include_entities=true&include_user_entities=true&include_ext_media_color=true&include_ext_media_availability=true&include_ext_sensitive_media_warning=true&send_error_codes=true&simple_quoted_tweet=true&q=${query}&tweet_search_mode=live&count=${filter.count}&query_source=typed_query&pc=1&spelling_corrections=1&ext=mediaStats%2ChighlightedLabel%2ChasNftAvatar%2CvoiceInfo%2CsuperFollowMetadata`;
-    }
-
-    return url;
+    return url = `https://api.twitter.com/2/search/adaptive.json?q=${query}&query_source=typed_query&count=${filter.count}`;
 }
 
 /**

--- a/src/services/helper/Urls.ts
+++ b/src/services/helper/Urls.ts
@@ -67,8 +67,8 @@ export function tweetsUrl(filter: TweetFilter, cursor: string): string {
     let query = [
         filter.words ? filter.words.join(' ') : '',
         filter.hashtags ? `(${filter.hashtags.map(hashtag => '%23' + hashtag).join(' OR ')})` : '',
-        filter.fromUsers ? `(${filter.fromUsers.map(user => `from%3A${user}`).join(' OR ')})` : '',
-        filter.toUsers ? `(${filter.toUsers.map(user => `to%3A${user}`).join(' OR ')})` : '',
+        filter.fromUsers ? `(${filter.fromUsers.map(user => `from:${user}`).join(' OR ')})` : '',
+        filter.toUsers ? `(${filter.toUsers.map(user => `to:${user}`).join(' OR ')})` : '',
         filter.mentions ? `(${filter.mentions.map(mention => '%40' + mention).join(' OR ')})` : '',
         filter.startDate ? `since:${filter.startDate}` : '',
         filter.endDate ? `until:${filter.endDate}` : '',

--- a/src/services/helper/Urls.ts
+++ b/src/services/helper/Urls.ts
@@ -1,6 +1,3 @@
-// TYPES
-import { TweetFilter } from "../../types/Tweet";
-
 /**
  * @returns The url for fetching user account details.
  * @param screenName The screen name of the target user
@@ -59,27 +56,12 @@ export function userTweetsUrl(userId: string, count: number, cursor: string): st
 
 /**
  * @returns The url for fetching the list of tweets matching the given filter
- * @param filter The filter to be used for searching tweets
+ * @param query The query to be used for searching tweets
+ * @param count The number of tweets to fetch
  * @param cursor The cusor to next batch * 
  */
-export function tweetsUrl(filter: TweetFilter, cursor: string): string {
-    // Concatenating the input argument lists to a URL query formatted string
-    let query = [
-        filter.words ? filter.words.join(' ') : '',
-        filter.hashtags ? `(${filter.hashtags.map(hashtag => '%23' + hashtag).join(' OR ')})` : '',
-        filter.fromUsers ? `(${filter.fromUsers.map(user => `from:${user}`).join(' OR ')})` : '',
-        filter.toUsers ? `(${filter.toUsers.map(user => `to:${user}`).join(' OR ')})` : '',
-        filter.mentions ? `(${filter.mentions.map(mention => '%40' + mention).join(' OR ')})` : '',
-        filter.startDate ? `since:${filter.startDate}` : '',
-        filter.endDate ? `until:${filter.endDate}` : '',
-        filter.quoted ? `quoted_tweet_id:${filter.quoted}` : ''
-    ]
-    .filter(item => item !== '()' && item !== '')
-    .join(' ');
-
-    let url = '';
-
-    return url = `https://api.twitter.com/2/search/adaptive.json?include_want_retweets=1&include_quote_count=true&include_reply_count=1&include_entities=true&include_user_entities=true&simple_quoted_tweet=true&q=${query}&tweet_search_mode=live&count=${filter.count}&query_source=typed_query&cursor=${cursor}`;
+export function tweetsUrl(query: string, count: number, cursor: string): string {
+    return `https://api.twitter.com/2/search/adaptive.json?include_want_retweets=1&include_quote_count=true&include_reply_count=1&include_entities=true&include_user_entities=true&simple_quoted_tweet=true&q=${query}&tweet_search_mode=live&count=${count}&query_source=typed_query&cursor=${cursor}`;
 }
 
 /**

--- a/src/services/helper/Urls.ts
+++ b/src/services/helper/Urls.ts
@@ -67,8 +67,8 @@ export function tweetsUrl(filter: TweetFilter, cursor: string): string {
     let query = [
         filter.words ? filter.words.join(' ') : '',
         filter.hashtags ? `(${filter.hashtags.map(hashtag => '%23' + hashtag).join(' OR ')})` : '',
-        filter.fromUsers ? `(${filter.fromUsers.map(user => `from:${user}`).join(' OR ')})` : '',
-        filter.toUsers ? `(${filter.toUsers.map(user => `to:${user}`).join(' OR ')})` : '',
+        filter.fromUsers ? `(${filter.fromUsers.map(user => `from%3A${user}`).join(' OR ')})` : '',
+        filter.toUsers ? `(${filter.toUsers.map(user => `to%3A${user}`).join(' OR ')})` : '',
         filter.mentions ? `(${filter.mentions.map(mention => '%40' + mention).join(' OR ')})` : '',
         filter.startDate ? `since:${filter.startDate}` : '',
         filter.endDate ? `until:${filter.endDate}` : '',
@@ -79,7 +79,7 @@ export function tweetsUrl(filter: TweetFilter, cursor: string): string {
 
     let url = '';
 
-    return url = `https://api.twitter.com/2/search/adaptive.json?q=${query}&query_source=typed_query&count=${filter.count}`;
+    return url = `https://api.twitter.com/2/search/adaptive.json?include_want_retweets=1&include_quote_count=true&include_reply_count=1&include_entities=true&include_user_entities=true&simple_quoted_tweet=true&q=${query}&tweet_search_mode=live&count=${filter.count}&query_source=typed_query&cursor=${cursor}`;
 }
 
 /**

--- a/src/types/Tweet.ts
+++ b/src/types/Tweet.ts
@@ -12,7 +12,6 @@ export interface TweetFilter {
     startDate: string;                                                  // To store the beginning date to search tweets
     endDate: string;                                                    // To store the ending date to search tweets
     quoted: string;                                                     // To store the id of the tweet which is quoted
-    count: number;                                                      // To store the number of tweets to fetch
 };
 
 /**

--- a/src/types/raw/tweet/Tweet.ts
+++ b/src/types/raw/tweet/Tweet.ts
@@ -189,7 +189,7 @@ export interface Legacy2 {
     extended_entities: ExtendedEntities
     favorite_count: number
     favorited: boolean
-    full_text: string
+    text: string
     in_reply_to_status_id_str: string
     is_quote_status: boolean
     lang: string


### PR DESCRIPTION
- Added back fetching of filtered tweets
- Removed stub type def for express graphql
- User tweets are now fetched using the global tweet search endpoint
- Updated tweet url
- Fixed some typos
- removed count from tweet filter and used it as a separate argument everywhere
- Updated indentations
