### PR TITLE
Added functionality to post Tweets, Likes and Retweets

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"axios": "1.3.2",
 		"rettiwt-auth": "1.2.0",
-		"rettiwt-core": "3.0.0-rc.2"
+		"rettiwt-core": "^3.0.0-alpha.0"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"axios": "1.3.2",
 		"rettiwt-auth": "1.2.0",
-		"rettiwt-core": "3.0.0-rc.1"
+		"rettiwt-core": "3.0.0-rc.2"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"axios": "1.3.2",
 		"rettiwt-auth": "1.2.0",
-		"rettiwt-core": "^3.0.0-alpha.0"
+		"rettiwt-core": "3.0.0-alpha.1"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"axios": "1.3.2",
 		"rettiwt-auth": "1.2.0",
-		"rettiwt-core": "2.5.2"
+		"rettiwt-core": "3.0.0-rc.1"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -6,6 +6,7 @@ import {
 	ICursor as IRawCursor,
 	ITweet as IRawTweet,
 	IUser as IRawUser,
+	IResponse,
 } from 'rettiwt-core';
 import axios, { AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from 'axios';
 import { AuthCredential } from 'rettiwt-auth';
@@ -43,7 +44,7 @@ export class FetcherService {
 	 * @param res - The response object received.
 	 * @returns The received response, if no HTTP errors are found.
 	 */
-	private handleHTTPError(res: AxiosResponse): AxiosResponse {
+	private handleHTTPError(res: AxiosResponse<IResponse<unknown>>): AxiosResponse<IResponse<unknown>> {
 		/**
 		 * If the status code is not 200 =\> the HTTP request was not successful. hence throwing error
 		 */
@@ -61,7 +62,7 @@ export class FetcherService {
 	 * @typeParam T - Type of response data.
 	 * @returns The response received.
 	 */
-	private async request(config: Request): Promise<AxiosResponse<NonNullable<unknown>>> {
+	private async request(config: Request): Promise<AxiosResponse<IResponse<unknown>>> {
 		/**
 		 * Creating axios request configuration from the input configuration.
 		 */
@@ -75,7 +76,7 @@ export class FetcherService {
 		/**
 		 * After making the request, the response is then passed to HTTP error handling middlware for HTTP error handling.
 		 */
-		return await axios(axiosRequest).then((res) => this.handleHTTPError(res));
+		return await axios<IResponse<unknown>>(axiosRequest).then((res) => this.handleHTTPError(res));
 	}
 
 	/**

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -143,13 +143,11 @@ export class FetcherService {
 	 * @param args - Resource specific arguments.
 	 * @returns Whether posting was successful or not.
 	 */
-	protected async post(resourceType: EResourceType, args: Args): Promise<boolean> {
+	protected async post(resourceType: EResourceType, args: Args): Promise<void> {
 		// Preparing the HTTP request
 		const request: Request = new Request(resourceType, args);
 
 		// Posting the data
-		const res = await this.request(request);
-
-		return res.data ? true : false;
+		await this.request(request);
 	}
 }

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -143,11 +143,13 @@ export class FetcherService {
 	 * @param args - Resource specific arguments.
 	 * @returns Whether posting was successful or not.
 	 */
-	protected async post(resourceType: EResourceType, args: Args): Promise<void> {
+	protected async post(resourceType: EResourceType, args: Args): Promise<boolean> {
 		// Preparing the HTTP request
 		const request: Request = new Request(resourceType, args);
 
 		// Posting the data
-		await this.request(request);
+		const res = await this.request(request);
+
+		return (!(res.data.errors));
 	}
 }

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -1,5 +1,12 @@
 // PACKAGES
-import { Request, Args, EResourceType, ICursor as IRawCursor, ITweet as IRawTweet, IUser as IRawUser } from 'rettiwt-core';
+import {
+	Request,
+	Args,
+	EResourceType,
+	ICursor as IRawCursor,
+	ITweet as IRawTweet,
+	IUser as IRawUser,
+} from 'rettiwt-core';
 import axios, { AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from 'axios';
 import { AuthCredential } from 'rettiwt-auth';
 
@@ -134,15 +141,15 @@ export class FetcherService {
 	 *
 	 * @param resourceType - The type of resource to post.
 	 * @param args - Resource specific arguments.
-	 * @returns The response received from Twitter.
+	 * @returns Whether posting was successful or not.
 	 */
-	protected async post(resourceType: EResourceType, args: Args): Promise<unknown> {
+	protected async post(resourceType: EResourceType, args: Args): Promise<boolean> {
 		// Preparing the HTTP request
 		const request: Request = new Request(resourceType, args);
 
 		// Posting the data
 		const res = await this.request(request);
 
-		return (res.data);
+		return res.data ? true : false;
 	}
 }

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -128,4 +128,21 @@ export class FetcherService {
 
 		return data;
 	}
+
+	/**
+	 * Posts the requested resource to Twitter and returns the response.
+	 *
+	 * @param resourceType - The type of resource to post.
+	 * @param args - Resource specific arguments.
+	 * @returns The response received from Twitter.
+	 */
+	protected async post(resourceType: EResourceType, args: Args): Promise<unknown> {
+		// Preparing the HTTP request
+		const request: Request = new Request(resourceType, args);
+
+		// Posting the data
+		const res = await this.request(request);
+
+		return (res.data);
+	}
 }

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -1,5 +1,5 @@
 // PACKAGES
-import { Url, Args, EResourceType, ICursor as IRawCursor, ITweet as IRawTweet, IUser as IRawUser } from 'rettiwt-core';
+import { Request, Args, EResourceType, ICursor as IRawCursor, ITweet as IRawTweet, IUser as IRawUser } from 'rettiwt-core';
 import axios, { AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from 'axios';
 import { AuthCredential } from 'rettiwt-auth';
 
@@ -114,11 +114,11 @@ export class FetcherService {
 		resourceType: EResourceType,
 		args: Args,
 	): Promise<CursoredData<OutType>> {
-		// Preparing the URL
-		const url: string = new Url(resourceType, args).toString();
+		// Preparing the HTTP request
+		const request: Request = new Request(resourceType, args);
 
 		// Getting the raw data
-		const res = await this.request(url).then((res) => res.data);
+		const res = await this.request(request.url).then((res) => res.data);
 
 		// Extracting data
 		const data = this.extractData<IRawTweet | IRawUser, OutType>(res, resourceType);

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -50,22 +50,25 @@ export class FetcherService {
 	/**
 	 * Makes an HTTP request according to the given parameters.
 	 *
-	 * @param url - The url to fetch data from.
+	 * @param config - The request configuration.
 	 * @typeParam T - Type of response data.
 	 * @returns The response received.
 	 */
-	private async request(url: string): Promise<AxiosResponse<NonNullable<unknown>>> {
+	private async request(config: Request): Promise<AxiosResponse<NonNullable<unknown>>> {
 		/**
-		 * Creating the request configuration based on the params
+		 * Creating axios request configuration from the input configuration.
 		 */
-		const config: AxiosRequestConfig = {
+		const axiosRequest: AxiosRequestConfig = {
+			url: config.url,
+			method: config.type,
+			data: config.payload,
 			headers: JSON.parse(JSON.stringify(this.cred.toHeader())) as AxiosRequestHeaders,
 		};
 
 		/**
 		 * After making the request, the response is then passed to HTTP error handling middlware for HTTP error handling.
 		 */
-		return await axios.get(url, config).then((res) => this.handleHTTPError(res));
+		return await axios(axiosRequest).then((res) => this.handleHTTPError(res));
 	}
 
 	/**
@@ -118,7 +121,7 @@ export class FetcherService {
 		const request: Request = new Request(resourceType, args);
 
 		// Getting the raw data
-		const res = await this.request(request.url).then((res) => res.data);
+		const res = await this.request(request).then((res) => res.data);
 
 		// Extracting data
 		const data = this.extractData<IRawTweet | IRawUser, OutType>(res, resourceType);

--- a/src/services/FetcherService.ts
+++ b/src/services/FetcherService.ts
@@ -59,7 +59,6 @@ export class FetcherService {
 	 * Makes an HTTP request according to the given parameters.
 	 *
 	 * @param config - The request configuration.
-	 * @typeParam T - Type of response data.
 	 * @returns The response received.
 	 */
 	private async request(config: Request): Promise<AxiosResponse<IResponse<unknown>>> {

--- a/src/services/TweetService.ts
+++ b/src/services/TweetService.ts
@@ -114,9 +114,11 @@ export class TweetService extends FetcherService {
 	 *
 	 * @public
 	 */
-	async tweet(tweetText: string): Promise<void> {
+	async tweet(tweetText: string): Promise<boolean> {
 		// Posting the tweet
-		await this.post(EResourceType.CREATE_TWEET, { tweetText: tweetText });
+		const data = this.post(EResourceType.CREATE_TWEET, { tweetText: tweetText });
+
+		return data;
 	}
 
 	/**
@@ -124,10 +126,14 @@ export class TweetService extends FetcherService {
 	 * 
 	 * @param tweetId - The id of the tweet to be favorited.
 	 * @returns Whether favoriting was successful or not.
+	 * 
+	 * @public
 	 */
-	async favorite(tweetId: string): Promise<void> {
+	async favorite(tweetId: string): Promise<boolean> {
 		// Favoriting the tweet
-		await this.post(EResourceType.FAVORITE_TWEET, { id: tweetId });
+		const data = await this.post(EResourceType.FAVORITE_TWEET, { id: tweetId });
+
+		return data;
 	}
 
 	/**
@@ -135,9 +141,13 @@ export class TweetService extends FetcherService {
 	 * 
 	 * @param tweetId - The id of the tweet with the given id.
 	 * @returns Whether retweeting was successful or not.
+	 * 
+	 * @public
 	 */
-	async retweet(tweetId: string): Promise<void> {
+	async retweet(tweetId: string): Promise<boolean> {
 		// Retweeting the tweet
-		await this.post(EResourceType.CREATE_RETWEET, { id: tweetId });
+		const data = await this.post(EResourceType.CREATE_RETWEET, { id: tweetId });
+
+		return data;
 	}
 }

--- a/src/services/TweetService.ts
+++ b/src/services/TweetService.ts
@@ -105,4 +105,19 @@ export class TweetService extends FetcherService {
 
 		return data;
 	}
+
+	/**
+	 * Post a tweet.
+	 *
+	 * @param text - The text to be posted, length must be \<= 280 characters.
+	 * @returns Whether posting was successful or not.
+	 *
+	 * @public
+	 */
+	async tweet(text: string): Promise<boolean> {
+		// Posting the tweet
+		const res = await this.post(EResourceType.CREATE_TWEET, { tweetText: text });
+
+		return res;
+	}
 }

--- a/src/services/TweetService.ts
+++ b/src/services/TweetService.ts
@@ -114,11 +114,9 @@ export class TweetService extends FetcherService {
 	 *
 	 * @public
 	 */
-	async tweet(tweetText: string): Promise<boolean> {
+	async tweet(tweetText: string): Promise<void> {
 		// Posting the tweet
-		const res = await this.post(EResourceType.CREATE_TWEET, { tweetText: tweetText });
-
-		return res;
+		await this.post(EResourceType.CREATE_TWEET, { tweetText: tweetText });
 	}
 
 	/**
@@ -127,11 +125,9 @@ export class TweetService extends FetcherService {
 	 * @param tweetId - The id of the tweet to be favorited.
 	 * @returns Whether favoriting was successful or not.
 	 */
-	async favorite(tweetId: string): Promise<boolean> {
+	async favorite(tweetId: string): Promise<void> {
 		// Favoriting the tweet
-		const res = await this.post(EResourceType.FAVORITE_TWEET, { id: tweetId });
-
-		return res;
+		await this.post(EResourceType.FAVORITE_TWEET, { id: tweetId });
 	}
 
 	/**
@@ -140,10 +136,8 @@ export class TweetService extends FetcherService {
 	 * @param tweetId - The id of the tweet with the given id.
 	 * @returns Whether retweeting was successful or not.
 	 */
-	async retweet(tweetId: string): Promise<boolean> {
+	async retweet(tweetId: string): Promise<void> {
 		// Retweeting the tweet
-		const res = await this.post(EResourceType.CREATE_RETWEET, { id: tweetId });
-
-		return res;
+		await this.post(EResourceType.CREATE_RETWEET, { id: tweetId });
 	}
 }

--- a/src/services/TweetService.ts
+++ b/src/services/TweetService.ts
@@ -109,14 +109,40 @@ export class TweetService extends FetcherService {
 	/**
 	 * Post a tweet.
 	 *
-	 * @param text - The text to be posted, length must be \<= 280 characters.
+	 * @param tweetText - The text to be posted, length must be \<= 280 characters.
 	 * @returns Whether posting was successful or not.
 	 *
 	 * @public
 	 */
-	async tweet(text: string): Promise<boolean> {
+	async tweet(tweetText: string): Promise<boolean> {
 		// Posting the tweet
-		const res = await this.post(EResourceType.CREATE_TWEET, { tweetText: text });
+		const res = await this.post(EResourceType.CREATE_TWEET, { tweetText: tweetText });
+
+		return res;
+	}
+
+	/**
+	 * Favorite the tweet with the given id.
+	 * 
+	 * @param tweetId - The id of the tweet to be favorited.
+	 * @returns Whether favoriting was successful or not.
+	 */
+	async favorite(tweetId: string): Promise<boolean> {
+		// Favoriting the tweet
+		const res = await this.post(EResourceType.FAVORITE_TWEET, { id: tweetId });
+
+		return res;
+	}
+
+	/**
+	 * Retweet the tweet with the given id.
+	 * 
+	 * @param tweetId - The id of the tweet with the given id.
+	 * @returns Whether retweeting was successful or not.
+	 */
+	async retweet(tweetId: string): Promise<boolean> {
+		// Retweeting the tweet
+		const res = await this.post(EResourceType.CREATE_RETWEET, { id: tweetId });
 
 		return res;
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@ rettiwt-auth@1.2.0:
     axios "1.4.0"
     cookiejar "2.1.4"
 
-rettiwt-core@3.0.0-rc.1:
-  version "3.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-rc.1.tgz#fab95d171e29ed088b330af3a6302b58f7523fca"
-  integrity sha512-cLx9Tpqlsg948noGfPbMcYV+Sbj8S7BEktG2HaVlUxxowW46i3kNeuBl78bpiKcfKQG0O7SFvz7IAZl1b5DANA==
+rettiwt-core@3.0.0-rc.2:
+  version "3.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-rc.2.tgz#1899424ce076577c66ba07a2070fab564dd95b9e"
+  integrity sha512-yCy9TqEyomp/BdBK3fBYja/E1mO99nXABBUz9LiEQAAe6MVBWJzqGkaJvNgb7pSIe3Da5OnBlxSYhtTp5dKMRw==
   dependencies:
     class-validator "0.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@ rettiwt-auth@1.2.0:
     axios "1.4.0"
     cookiejar "2.1.4"
 
-rettiwt-core@3.0.0-rc.2:
-  version "3.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-rc.2.tgz#1899424ce076577c66ba07a2070fab564dd95b9e"
-  integrity sha512-yCy9TqEyomp/BdBK3fBYja/E1mO99nXABBUz9LiEQAAe6MVBWJzqGkaJvNgb7pSIe3Da5OnBlxSYhtTp5dKMRw==
+rettiwt-core@^3.0.0-alpha.0:
+  version "3.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-alpha.0.tgz#ac2676d25235f3f246eee83f148f00253b76ab44"
+  integrity sha512-VE79MzI+0Jd5ueH5Cca9OyDCHsAq+w26+PS2YpYkmZTlqARtz6hK75233FtTn3Pu3RowyCFDWr/GDLG1FirLYw==
   dependencies:
     class-validator "0.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@ rettiwt-auth@1.2.0:
     axios "1.4.0"
     cookiejar "2.1.4"
 
-rettiwt-core@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-2.5.2.tgz#a6041e1289343a331b73a7df7e528a7c0d574a74"
-  integrity sha512-dM+x29As/mDK8TaR1xrIhAJ3gP7AIdQSuXB4WDQ9gnBMaA+ra0ggud6dCoAz6M/6OYoPWWjsO0ZvgUrAOs1H5w==
+rettiwt-core@3.0.0-rc.1:
+  version "3.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-rc.1.tgz#fab95d171e29ed088b330af3a6302b58f7523fca"
+  integrity sha512-cLx9Tpqlsg948noGfPbMcYV+Sbj8S7BEktG2HaVlUxxowW46i3kNeuBl78bpiKcfKQG0O7SFvz7IAZl1b5DANA==
   dependencies:
     class-validator "0.14.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@ rettiwt-auth@1.2.0:
     axios "1.4.0"
     cookiejar "2.1.4"
 
-rettiwt-core@^3.0.0-alpha.0:
-  version "3.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-alpha.0.tgz#ac2676d25235f3f246eee83f148f00253b76ab44"
-  integrity sha512-VE79MzI+0Jd5ueH5Cca9OyDCHsAq+w26+PS2YpYkmZTlqARtz6hK75233FtTn3Pu3RowyCFDWr/GDLG1FirLYw==
+rettiwt-core@^3.0.0-alpha.1:
+  version "3.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.0.0-alpha.1.tgz#6fc0862d6f62e208eba521b31c8e5923a6860aad"
+  integrity sha512-9SAqDHT7Y/tBF7OUMBCGN3N/7fq8j3Ff2BPgY4oJ+eLBXZILh1zO6IW6fLvCSHeOwDTxeOtxBQ3ig5UyvEl8Kg==
   dependencies:
     class-validator "0.14.0"
 


### PR DESCRIPTION
- Migrated to Rettiwt-Core v3.0.0-rc.1
- FetcherServices.request method now takes a request configuration as input
- Added FetcherService.post method to post data to twitter
- Added TweetService.tweet method to post a tweet
- Updated rettiwt-core
- Added functionality to post likes and retweets
- Posting data does not return anything(for now)
- Updated rettiwt-core to alpha
- Updated rettiwt-core to latest alpha
- FetcherService.request method now return an AxiosResponse of type standard Twitter response
- Removed unnecessary comment
- Post methods now return whether posting was successful or not
