### PR TITLE
Added more options while searching for tweets

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
 	"bracketSpacing": true,
 	"endOfLine": "auto",
 	"printWidth": 120,
-	"quoteProps": "consistent",
+	"quoteProps": "as-needed",
 	"semi": true,
 	"singleQuote": true,
 	"tabWidth": 4,

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -122,10 +122,21 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
  * @remarks The search options are implementations of the ones offered by {@link TweetFilter}
  */
 class TweetSearchOptions {
+	/* eslint-disable @typescript-eslint/naming-convention */
 	public from?: string;
 	public to?: string;
 	public words?: string;
+	public phrase?: string;
+	public 'optional-words'?: string;
+	public 'exclude-words'?: string;
 	public hashtags?: string;
+	public mentions?: string;
+	public 'min-replies'?: number;
+	public 'min-likes'?: number;
+	public 'min-retweets'?: number;
+	public quoted?: string;
+	public links?: boolean;
+	public replies?: boolean;
 	public start?: string;
 	public end?: string;
 
@@ -138,7 +149,17 @@ class TweetSearchOptions {
 		this.from = options?.from;
 		this.to = options?.to;
 		this.words = options?.words;
+		this.phrase = options?.phrase;
+		this['optional-words'] = options?.['optional-words'];
+		this['exclude-words'] = options?.['exclude-words'];
 		this.hashtags = options?.hashtags;
+		this.mentions = options?.mentions;
+		this['min-replies'] = options?.['min-replies'];
+		this['min-likes'] = options?.['min-likes'];
+		this['min-retweets'] = options?.['min-retweets'];
+		this.quoted = options?.quoted;
+		this.links = options?.links;
+		this.replies = options?.replies;
 		this.start = options?.start;
 		this.end = options?.end;
 	}
@@ -153,7 +174,17 @@ class TweetSearchOptions {
 			fromUsers: this.from ? this.from.split(';') : undefined,
 			toUsers: this.to ? this.to.split(';') : undefined,
 			includeWords: this.words ? this.words.split(';') : undefined,
+			includePhrase: this.phrase,
+			optionalWords: this['optional-words'] ? this['optional-words'].split(';') : undefined,
+			excludeWords: this['exclude-words'] ? this['exclude-words'].split(';') : undefined,
 			hashtags: this.hashtags ? this.hashtags.split(';') : undefined,
+			mentions: this.mentions ? this.mentions.split(';') : undefined,
+			minReplies: this['min-replies'],
+			minLikes: this['min-likes'],
+			minRetweets: this['min-retweets'],
+			quoted: this.quoted,
+			links: this.links,
+			replies: this.replies,
 			startDate: this.start ? new Date(this.start) : undefined,
 			endDate: this.end ? new Date(this.end) : undefined,
 		});

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -46,8 +46,7 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		)
 		.option('-h, --hashtags <string>', "Matches the tweets containing the given list of hashtags, separated by ';'")
 		.option(
-			'-m',
-			'--mentions <string>',
+			'-m, --mentions <string>',
 			"Matches the tweets that mention the give list of usernames, separated by ';'",
 		)
 		.option('-r, --min-replies <number>', 'Matches the tweets that have a minimum of given number of replies')

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -141,21 +141,20 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
  * @remarks The search options are implementations of the ones offered by {@link TweetFilter}
  */
 class TweetSearchOptions {
-	/* eslint-disable @typescript-eslint/naming-convention */
 	public from?: string;
 	public to?: string;
 	public words?: string;
 	public phrase?: string;
-	public 'optional-words'?: string;
-	public 'exclude-words'?: string;
+	public optionalWords?: string;
+	public excludeWords?: string;
 	public hashtags?: string;
 	public mentions?: string;
-	public 'min-replies'?: number;
-	public 'min-likes'?: number;
-	public 'min-retweets'?: number;
+	public minReplies?: number;
+	public minLikes?: number;
+	public minRetweets?: number;
 	public quoted?: string;
-	public 'exclude-links'?: boolean;
-	public 'exclude-replies'?: boolean;
+	public excludeLinks?: boolean = false;
+	public excludeReplies?: boolean = false;
 	public start?: string;
 	public end?: string;
 
@@ -169,16 +168,16 @@ class TweetSearchOptions {
 		this.to = options?.to;
 		this.words = options?.words;
 		this.phrase = options?.phrase;
-		this['optional-words'] = options?.['optional-words'];
-		this['exclude-words'] = options?.['exclude-words'];
+		this.optionalWords = options?.optionalWords;
+		this.excludeWords = options?.excludeWords;
 		this.hashtags = options?.hashtags;
 		this.mentions = options?.mentions;
-		this['min-replies'] = options?.['min-replies'];
-		this['min-likes'] = options?.['min-likes'];
-		this['min-retweets'] = options?.['min-retweets'];
+		this.minReplies = options?.minReplies;
+		this.minLikes = options?.minLikes;
+		this.minRetweets = options?.minRetweets;
 		this.quoted = options?.quoted;
-		this['exclude-links'] = options?.['exclude-links'];
-		this['exclude-replies'] = options?.['exclude-replies'];
+		this.excludeLinks = options?.excludeLinks;
+		this.excludeReplies = options?.excludeReplies;
 		this.start = options?.start;
 		this.end = options?.end;
 	}
@@ -194,16 +193,16 @@ class TweetSearchOptions {
 			toUsers: this.to ? this.to.split(';') : undefined,
 			includeWords: this.words ? this.words.split(';') : undefined,
 			includePhrase: this.phrase,
-			optionalWords: this['optional-words'] ? this['optional-words'].split(';') : undefined,
-			excludeWords: this['exclude-words'] ? this['exclude-words'].split(';') : undefined,
+			optionalWords: this.optionalWords ? this.optionalWords.split(';') : undefined,
+			excludeWords: this.excludeWords ? this.excludeWords.split(';') : undefined,
 			hashtags: this.hashtags ? this.hashtags.split(';') : undefined,
 			mentions: this.mentions ? this.mentions.split(';') : undefined,
-			minReplies: this['min-replies'],
-			minLikes: this['min-likes'],
-			minRetweets: this['min-retweets'],
+			minReplies: this.minReplies,
+			minLikes: this.minLikes,
+			minRetweets: this.minRetweets,
 			quoted: this.quoted,
-			links: !this['exclude-links'],
-			replies: !this['exclude-replies'],
+			links: !this.excludeLinks,
+			replies: !this.excludeReplies,
 			startDate: this.start ? new Date(this.start) : undefined,
 			endDate: this.end ? new Date(this.end) : undefined,
 		});

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -35,7 +35,27 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.option('-f, --from <string>', "Matches the tweets made by list of given users, separated by ';'")
 		.option('-t, --to <string>', "Matches the tweets made to the list of given users, separated by ';'")
 		.option('-w, --words <string>', "Matches the tweets containing the given list of words, separated by ';'")
+		.option('-p, --phrase <string>', 'Matches the tweets containing the exact phrase')
+		.option(
+			'--optional-words <string>',
+			"Matches the tweets containing any of the given list of words, separated by ';'",
+		)
+		.option(
+			'--exclude-words <string>',
+			"Matches the tweets that do not contain any of the give list of words, separated by ';'",
+		)
 		.option('-h, --hashtags <string>', "Matches the tweets containing the given list of hashtags, separated by ';'")
+		.option(
+			'-m',
+			'--mentions <string>',
+			"Matches the tweets that mention the give list of usernames, separated by ';'",
+		)
+		.option('-r, --min-replies <number>', 'Matches the tweets that have a minimum of given number of replies')
+		.option('-l, --min-likes <number>', 'Matches the tweets that have a minimum of given number of likes')
+		.option('-x, --min-retweets <number>', 'Matches the tweets that have a minimum of given number of retweets')
+		.option('-q, --quoted <string>', 'Matches the tweets that quote the tweet with the given id')
+		.option('--exclude-links', 'Matches tweets that do not contain links')
+		.option('--exclude-replies', 'Matches the tweets that are not replies')
 		.option('-s, --start <string>', 'Matches the tweets made since the given date (valid date string)')
 		.option('-e, --end <string>', 'Matches the tweets made upto the given date (valid date string)')
 		.action(async (count?: string, cursor?: string, options?: TweetSearchOptions) => {
@@ -135,8 +155,8 @@ class TweetSearchOptions {
 	public 'min-likes'?: number;
 	public 'min-retweets'?: number;
 	public quoted?: string;
-	public links?: boolean;
-	public replies?: boolean;
+	public 'exclude-links'?: boolean;
+	public 'exclude-replies'?: boolean;
 	public start?: string;
 	public end?: string;
 
@@ -158,8 +178,8 @@ class TweetSearchOptions {
 		this['min-likes'] = options?.['min-likes'];
 		this['min-retweets'] = options?.['min-retweets'];
 		this.quoted = options?.quoted;
-		this.links = options?.links;
-		this.replies = options?.replies;
+		this['exclude-links'] = options?.['exclude-links'];
+		this['exclude-replies'] = options?.['exclude-replies'];
 		this.start = options?.start;
 		this.end = options?.end;
 	}
@@ -183,8 +203,8 @@ class TweetSearchOptions {
 			minLikes: this['min-likes'],
 			minRetweets: this['min-retweets'],
 			quoted: this.quoted,
-			links: this.links,
-			replies: this.replies,
+			links: !this['exclude-links'],
+			replies: !this['exclude-replies'],
 			startDate: this.start ? new Date(this.start) : undefined,
 			endDate: this.end ? new Date(this.end) : undefined,
 		});


### PR DESCRIPTION
The following TweetFilter options were added/modified:

1. words -> includeWords
2. includePhrase
3. optionalWords
4. excludeWords
5. minReplies
6. minLikes
7. minRetweets

In additions, these options were also added to the CLI tweet search command:

1. phrase
2. optionalWords
3. excludeWords
4. mentions
5. minReplies
6. minLikes
7. minRetweets
8. quoted
9. excludeLinks
10. excludeReplies