### PR TITLE
Added functionality to use a different proxy for authentcation and normal operation

### DIFF
--- a/src/services/internal/FetcherService.ts
+++ b/src/services/internal/FetcherService.ts
@@ -48,8 +48,8 @@ export class FetcherService {
 	/** Whether the instance is authenticated or not. */
 	private readonly isAuthenticated: boolean;
 
-	/** The URL to the proxy server to use. */
-	private readonly proxyUrl?: URL;
+	/** The URL to the proxy server to use for authentication. */
+	private readonly authProxyUrl?: URL;
 
 	/** The HTTPS Agent to use for requests to Twitter API. */
 	private readonly httpsAgent: Agent;
@@ -80,7 +80,7 @@ export class FetcherService {
 			this.cred = undefined;
 		}
 		this.isAuthenticated = config?.apiKey ? true : false;
-		this.proxyUrl = config?.proxyUrl;
+		this.authProxyUrl = config?.authProxyUrl ?? config?.proxyUrl;
 		this.httpsAgent = this.getHttpsAgent(config?.proxyUrl);
 		this.timeout = config?.timeout ?? 0;
 		this.logger = new LogService(config?.logging);
@@ -159,7 +159,7 @@ export class FetcherService {
 		this.checkAuthorization(config.url as EResourceType);
 
 		// If not authenticated, use guest authentication
-		this.cred = this.cred ?? (await new Auth({ proxyUrl: this.proxyUrl }).getGuestCredential());
+		this.cred = this.cred ?? (await new Auth({ proxyUrl: this.authProxyUrl }).getGuestCredential());
 
 		// Setting additional request parameters
 		config.headers = JSON.parse(JSON.stringify(this.cred.toHeader())) as AxiosRequestHeaders;

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -13,8 +13,21 @@ export interface IRettiwtConfig {
 	/** The guestKey (guest token) to use for guest access to Twitter API. */
 	guestKey?: string;
 
-	/** Optional URL with proxy configuration to use for requests to Twitter API. */
+	/**
+	 * Optional URL to proxy server to use for requests to Twitter API.
+	 *
+	 * @remarks When deploying to cloud platforms, if setting {@link IRettiwtConfig.authProxyUrl} does not resolve Error 429, then this might be required.
+	 */
 	proxyUrl?: URL;
+
+	/**
+	 * Optional URL to proxy server to use for authentication against Twitter API.
+	 *
+	 * @remarks Required when deploying to cloud platforms to bypass Error 429.
+	 *
+	 * @defaultValue Same as {@link IRettiwtConfig.proxyUrl}
+	 */
+	authProxyUrl?: URL;
 
 	/** The max wait time (in milli-seconds) for a response; if not set, Twitter server timeout is used. */
 	timeout?: number;


### PR DESCRIPTION
Using a separate proxy for authentication by setting the `authProxyUrl` parameter while configuring Rettiwt instance allows us to bypass Error 429 when deployed on cloud platforms, while normal data fetching and posting operations can continue to work without using a proxy, since only authentication required a proxy while normal operations did not.