### PR TITLE
Added CLI option to upload media in tweet

### DIFF
--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -107,8 +107,12 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.command('post')
 		.description('Post a tweet (text only)')
 		.argument('<text>', 'The text to post as a tweet')
-		.action(async (text: string) => {
-			const result = await rettiwt.tweet.tweet(text);
+		.option('-m, --media [string]', "The path to the media item(s) to be posted, separated by ';'")
+		.action(async (text: string, options?: { media?: string }) => {
+			const result = await rettiwt.tweet.tweet(
+				text,
+				options?.media ? options?.media.split(';').map((item) => ({ path: item })) : undefined,
+			);
 			output(result);
 		});
 


### PR DESCRIPTION
To upload media while posting a tweet, use the `-m` or `--media` option along with path(s) to media items(s) as follows:

`rettiwt tweet post "I love coding!" -m "<path_to_media1>;<path_to_media2>;<path_to_media3>"`

Where
-  <path_to_media> is the path to the media item to upload.
- ';' is the delimiter.