### PR TITLE
Added ability to post a reply to a tweet

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"commander": "11.1.0",
 		"https-proxy-agent": "7.0.2",
 		"rettiwt-auth": "2.1.0",
-		"rettiwt-core": "3.3.1"
+		"rettiwt-core": "3.4.0-alpha.2"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -108,10 +108,15 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.description('Post a tweet (text only)')
 		.argument('<text>', 'The text to post as a tweet')
 		.option('-m, --media [string]', 'Comma-separated list of path(s) to the media item(s) to be posted')
-		.action(async (text: string, options?: { media?: string }) => {
+		.option(
+			'-r, --reply [string]',
+			'The id of the tweet to which the reply is to be made, if the tweet is to be a reply',
+		)
+		.action(async (text: string, options?: { media?: string; reply?: string }) => {
 			const result = await rettiwt.tweet.tweet(
 				text,
 				options?.media ? options?.media.split(',').map((item) => ({ path: item })) : undefined,
+				options?.reply,
 			);
 			output(result);
 		});

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -261,9 +261,26 @@ export class TweetService extends FetcherService {
 	 * });
 	 * ```
 	 *
+	 * @example Posting a reply to a tweet
+	 * ```
+	 * import { Rettiwt } from 'rettiwt-api';
+	 *
+	 * // Creating a new Rettiwt instance using the given 'API_KEY'
+	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
+	 *
+	 * // Posting a simple text reply, to a tweet with id "1234567890"
+	 * rettiwt.tweet.tweet('Hello!', undefined, "1234567890")
+	 * .then(res => {
+	 * 	console.log(res);
+	 * })
+	 * .catch(err => {
+	 * 	console.log(err);
+	 * });
+	 * ```
+	 *
 	 * @public
 	 */
-	public async tweet(text: string, media?: TweetMediaArgs[]): Promise<boolean> {
+	public async tweet(text: string, media?: TweetMediaArgs[], replyTo?: string): Promise<boolean> {
 		// Converting  JSON args to object
 		const tweet: TweetArgs = new TweetArgs({ text: text, media: media });
 
@@ -282,7 +299,9 @@ export class TweetService extends FetcherService {
 		}
 
 		// Posting the tweet
-		const data = await this.post(EResourceType.CREATE_TWEET, { tweet: { text: text, media: uploadedMedia } });
+		const data = await this.post(EResourceType.CREATE_TWEET, {
+			tweet: { text: text, media: uploadedMedia, replyTo: replyTo },
+		});
 
 		return data;
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,10 +1090,10 @@ rettiwt-auth@2.1.0:
     cookiejar "2.1.4"
     https-proxy-agent "7.0.2"
 
-rettiwt-core@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.3.1.tgz#09ab32e66ba5b55d9ba9896e8dcd780f1b1f4e50"
-  integrity sha512-TNJFM1UQyfGT8FXPeqePMUk7qzBfoet2/Nzn7+Ma4ibyKdn+XCqaA1c10se02qYomQ7Lolc/KCZvhUPjwCJFXQ==
+rettiwt-core@3.4.0-alpha.2:
+  version "3.4.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.4.0-alpha.2.tgz#d3033d0db7a05f503e3b0aef5981d33897f0d08b"
+  integrity sha512-775cDTPWZXhY+znEOsjupIgj/Mmi8shKhLveShm1KnXEX1Qc5SjTEnpQv1dHmDaxiV9n6BIQ73E7K9AucBl+Mg==
   dependencies:
     axios "1.6.3"
     class-validator "0.14.1"


### PR DESCRIPTION
A reply can now be posted a tweet using the `tweet.tweet` method (the same method used to post a tweet), using a third optional parameter, as follows:

```
import { Rettiwt } from 'rettiwt-api';

// Creating a new Rettiwt instance using the given 'API_KEY'
const rettiwt = new Rettiwt({ apiKey: API_KEY });

// Posting a simple text reply, to a tweet with id "1234567890"
rettiwt.tweet.tweet('Hello!', undefined, "1234567890")
.then(res => {
    console.log(res);
})
.catch(err => {
    console.log(err);
});
```

The same can be done from CLI using an option `-r <target_tweet_id>` or `--reply <target_tweet_id>` while posting a tweet using the `post` command.

Closes #449
Closes #448