### PR TITLE
Fix tweet stream duplicates

### DIFF
--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -163,7 +163,6 @@ export class TweetService extends FetcherService {
 			// Else, start the next iteration from this batch's most recent tweet
 			else {
 				sinceId = nextSinceId;
-				nextSinceId = undefined;
 				cursor = undefined;
 			}
 		}


### PR DESCRIPTION
This fixes a bug where `Tweet#stream` would sometimes yield the same tweets over and over again. The reason this would happen is because `sinceId` (the most recent tweet ID to search from) could sometimes revert to `undefined`, which is never desired.

By no longer resetting `nextSinceId`, we guarantee that the subsequent batch begins after or at the same point as the previous one.