### PR TITLE
docs: Update npx command doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ However, in this case, for accessing the CLI, you will be required to prepend th
 
 For example, for generating the API_KEY, the command will be modified as follows:
 
-`npx rettiwt auth login <email> <username> <password>`
+`npx rettiwt-api auth login <email> <username> <password>`
 
 ## The Rettiwt class
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ However, in this case, for accessing the CLI, you will be required to prepend th
 
 For example, for generating the API_KEY, the command will be modified as follows:
 
+`npx rettiwt auth login <email> <username> <password>`
+
+In case you do not have the package installed or you run the command outside a node project, you can use `rettiwt-api`.
+
 `npx rettiwt-api auth login <email> <username> <password>`
 
 ## The Rettiwt class


### PR DESCRIPTION
The "rettiwt" command does not work with NPX if it is not installed or you try to run it outside the project, the alternative command in those cases would be "rettiwt-api".

![image](https://github.com/Rishikant181/Rettiwt-API/assets/67084442/5018d65e-aaac-4356-b741-0cf7319ca1df)
