### PR TITLE
Added functionality to efficiently quote a tweet

### DIFF
--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -122,16 +122,18 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.description('Post a tweet (text only)')
 		.argument('<text>', 'The text to post as a tweet')
 		.option('-m, --media [string]', 'Comma-separated list of path(s) to the media item(s) to be posted')
+		.option('-q, --quote [string]', 'The id of the tweet to quote in the tweet to be posted')
 		.option(
 			'-r, --reply [string]',
 			'The id of the tweet to which the reply is to be made, if the tweet is to be a reply',
 		)
-		.action(async (text: string, options?: { media?: string; reply?: string }) => {
-			const result = await rettiwt.tweet.tweet(
-				text,
-				options?.media ? options?.media.split(',').map((item) => ({ path: item })) : undefined,
-				options?.reply,
-			);
+		.action(async (text: string, options?: { media?: string; quote?: string; reply?: string }) => {
+			const result = await rettiwt.tweet.tweet({
+				text: text,
+				media: options?.media ? options?.media.split(',').map((item) => ({ path: item })) : undefined,
+				quote: options?.quote,
+				replyTo: options?.reply,
+			});
 			output(result);
 		});
 

--- a/src/models/args/TweetArgs.ts
+++ b/src/models/args/TweetArgs.ts
@@ -37,12 +37,24 @@ export class TweetArgs {
 	@IsObject({ each: true })
 	public media?: TweetMediaArgs[];
 
+	/**	The id of the tweet to which the reply is to be made. */
+	@IsOptional()
+	@IsNumberString()
+	public replyTo?: string;
+
+	/**	The id of the tweet to quote. */
+	@IsOptional()
+	@IsNumberString()
+	public quote?: string;
+
 	/**
 	 * @param tweet - The tweet arguments specifying the tweet.
 	 */
 	public constructor(tweet: TweetArgs) {
 		this.text = tweet.text;
 		this.media = tweet.media ? tweet.media.map((item) => new TweetMediaArgs(item)) : undefined;
+		this.replyTo = tweet.replyTo;
+		this.quote = tweet.quote;
 
 		// Validating this object
 		const validationResult = validateSync(this);

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -11,7 +11,7 @@ import { IRettiwtConfig } from '../../types/RettiwtConfig';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
 import { CursoredData } from '../../models/data/CursoredData';
-import { TweetArgs, TweetMediaArgs } from '../../models/args/TweetArgs';
+import { TweetArgs } from '../../models/args/TweetArgs';
 
 /**
  * Handles fetching of data related to tweets.
@@ -288,9 +288,7 @@ export class TweetService extends FetcherService {
 	/**
 	 * Post a tweet.
 	 *
-	 * @param text - The text to be posted, length must be \<= 280 characters.
-	 * @param media - The list of media to post in the tweet, max number of media must be \<= 4.
-	 * @param replyTo - The id of the tweet to which the reply is to be made.
+	 * @param options - The options describing the tweet to be posted.
 	 * @returns Whether posting was successful or not.
 	 *
 	 * @example Posting a simple text
@@ -301,7 +299,7 @@ export class TweetService extends FetcherService {
 	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
 	 *
 	 * // Posting a tweet to twitter
-	 * rettiwt.tweet.tweet('Hello World!')
+	 * rettiwt.tweet.tweet({ text: 'Hello World!' })
 	 * .then(res => {
 	 * 	console.log(res);
 	 * })
@@ -318,7 +316,7 @@ export class TweetService extends FetcherService {
 	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
 	 *
 	 * // Posting a tweet, containing an image called 'mountains.jpg', to twitter
-	 * rettiwt.tweet.tweet('What a nice view!', [{ path: 'mountains.jpg' }])
+	 * rettiwt.tweet.tweet({ text: 'What a nice view!', media: [{ path: 'mountains.jpg' }] })
 	 * .then(res => {
 	 * 	console.log(res);
 	 * })
@@ -341,7 +339,7 @@ export class TweetService extends FetcherService {
 	 * })
 	 * .then(image => {
 	 * 	// Posting a tweet, containing the image as an ArrayBuffer, to twitter
-	 * 	rettiwt.tweet.tweet('What a nice view!', [{ path: image.data }])
+	 * 	rettiwt.tweet.tweet({ text: 'What a nice view!', media: [{ path: image.data }] })
 	 * 	.then(res => {
 	 * 		console.log(res);
 	 * 	})
@@ -359,7 +357,24 @@ export class TweetService extends FetcherService {
 	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
 	 *
 	 * // Posting a simple text reply, to a tweet with id "1234567890"
-	 * rettiwt.tweet.tweet('Hello!', undefined, "1234567890")
+	 * rettiwt.tweet.tweet({ text: 'Hello!', replyTo: "1234567890" })
+	 * .then(res => {
+	 * 	console.log(res);
+	 * })
+	 * .catch(err => {
+	 * 	console.log(err);
+	 * });
+	 * ```
+	 *
+	 * * @example Posting a reply to a tweet with a quoted tweet
+	 * ```
+	 * import { Rettiwt } from 'rettiwt-api';
+	 *
+	 * // Creating a new Rettiwt instance using the given 'API_KEY'
+	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
+	 *
+	 * // Posting a simple text tweet, quoting a tweet with id "1234567890"
+	 * rettiwt.tweet.tweet({ text: 'Hello!', quote: "1234567890" })
 	 * .then(res => {
 	 * 	console.log(res);
 	 * })
@@ -370,9 +385,9 @@ export class TweetService extends FetcherService {
 	 *
 	 * @public
 	 */
-	public async tweet(text: string, media?: TweetMediaArgs[], replyTo?: string): Promise<boolean> {
+	public async tweet(options: TweetArgs): Promise<boolean> {
 		// Converting  JSON args to object
-		const tweet: TweetArgs = new TweetArgs({ text: text, media: media });
+		const tweet: TweetArgs = new TweetArgs(options);
 
 		/** Stores the list of media that has been uploaded */
 		const uploadedMedia: MediaArgs[] = [];
@@ -390,7 +405,12 @@ export class TweetService extends FetcherService {
 
 		// Posting the tweet
 		const data = await this.post(EResourceType.CREATE_TWEET, {
-			tweet: { text: text, media: uploadedMedia, replyTo: replyTo },
+			tweet: {
+				text: options.text,
+				media: uploadedMedia,
+				quote: options.quote,
+				replyTo: options.replyTo,
+			},
 		});
 
 		return data;


### PR DESCRIPTION
To accommodate this change, however, the way a new tweet is created is changed, as demonstrated below:

Old version:
```js
// Sending a reply called "Hello World" to a tweet with id 1234567890
rettiwt.tweet.tweet("Hello World!", undefined, "1234567890")
.then(res => {
    console.log(res);
}
.catch(err => {
    console.log(err);
}
```

New version:
```js
// Sending a reply called "Hello World" to a tweet with id 1234567890
rettiwt.tweet.tweet({ text: "Hello World!", replyTo: "1234567890" })
.then(res => {
    console.log(res);
}
.catch(err => {
    console.log(err);
}
```

Similarly, to quote a tweet, use the following example:
```js
// Quoting a tweet with id 1234567890 in a new tweet
rettiwt.tweet.tweet({ text: "Hello World!", quote: "1234567890" })
.then(res => {
    console.log(res);
}
.catch(err => {
    console.log(err);
}
```