### PR TITLE
Adopted a more consistent naming scheme for public methods

### DIFF
--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -94,19 +94,19 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 
 	// Likes
 	tweet
-		.command('likes')
+		.command('likers')
 		.description('Fetch the list of users who liked the given tweets')
 		.argument('<id>', 'The id of the tweet')
 		.argument('[count]', 'The number of likers to fetch')
 		.argument('[cursor]', 'The cursor to the batch of likers to fetch')
 		.action(async (id: string, count?: string, cursor?: string) => {
-			const tweets = await rettiwt.tweet.favoriters(id, count ? parseInt(count) : undefined, cursor);
+			const tweets = await rettiwt.tweet.likers(id, count ? parseInt(count) : undefined, cursor);
 			output(tweets);
 		});
 
 	// Retweets
 	tweet
-		.command('retweets')
+		.command('retweeters')
 		.description('Fetch the list of users who retweeted the given tweets')
 		.argument('<id>', 'The id of the tweet')
 		.argument('[count]', 'The number of retweeters to fetch')
@@ -143,7 +143,7 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.description('Like a tweet')
 		.argument('<id>', 'The tweet to like')
 		.action(async (id: string) => {
-			const result = await rettiwt.tweet.favorite(id);
+			const result = await rettiwt.tweet.like(id);
 			output(result);
 		});
 

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -236,7 +236,7 @@ export class TweetService extends FetcherService {
 	 *
 	 * @public
 	 */
-	public async favoriters(tweetId: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
+	public async likers(tweetId: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
 		// Fetching the requested data
 		const data = await this.fetch<User>(EResourceType.TWEET_FAVORITERS, {
 			id: tweetId,
@@ -417,10 +417,10 @@ export class TweetService extends FetcherService {
 	}
 
 	/**
-	 * Favorite the tweet with the given id.
+	 * Like the tweet with the given id.
 	 *
-	 * @param tweetId - The id of the tweet to be favorited.
-	 * @returns Whether favoriting was successful or not.
+	 * @param tweetId - The id of the tweet to be liked.
+	 * @returns Whether liking was successful or not.
 	 *
 	 * @example
 	 * ```
@@ -441,7 +441,7 @@ export class TweetService extends FetcherService {
 	 *
 	 * @public
 	 */
-	public async favorite(tweetId: string): Promise<boolean> {
+	public async like(tweetId: string): Promise<boolean> {
 		// Favoriting the tweet
 		const data = await this.post(EResourceType.FAVORITE_TWEET, { id: tweetId });
 


### PR DESCRIPTION
The following methods have been rename:

`Rettiwt.user`:
- `favoriters` -> `likers`

CLI:
- `tweet likes` -> `tweet likers`
- `tweet retweets` -> `tweet retweeters`