### PR TITLE
Removed count argument from user followers and following due to a bug in Twitter API

### DIFF
--- a/src/commands/User.ts
+++ b/src/commands/User.ts
@@ -30,11 +30,10 @@ function createUserCommand(rettiwt: Rettiwt): Command {
 	user.command('followers')
 		.description('Fetch the list of users who follow the given user')
 		.argument('<id>', 'The id of the user')
-		.argument('[count]', 'The number of followers to fetch')
 		.argument('[cursor]', 'The cursor to the batch of followers to fetch')
-		.action(async (id: string, count?: string, cursor?: string) => {
+		.action(async (id: string, cursor?: string) => {
 			try {
-				const users = await rettiwt.user.followers(id, count ? parseInt(count) : undefined, cursor);
+				const users = await rettiwt.user.followers(id, cursor);
 				output(users);
 			} catch (error) {
 				output(error);
@@ -45,11 +44,10 @@ function createUserCommand(rettiwt: Rettiwt): Command {
 	user.command('following')
 		.description('Fetch the list of users who are followed by the given user')
 		.argument('<id>', 'The id of the user')
-		.argument('[count]', 'The number of following to fetch')
 		.argument('[cursor]', 'The cursor to the batch of following to fetch')
-		.action(async (id: string, count?: string, cursor?: string) => {
+		.action(async (id: string, cursor?: string) => {
 			try {
-				const users = await rettiwt.user.following(id, count ? parseInt(count) : undefined, cursor);
+				const users = await rettiwt.user.following(id, cursor);
 				output(users);
 			} catch (error) {
 				output(error);

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -28,6 +28,7 @@ export class FetchArgs {
 	 *
 	 * @remarks
 	 * - Works only for cursored resources.
+	 * - Does not work for {@link EResourceType.USER_FOLLOWERS} and {@link EResourceType.USER_FOLLOWING}.
 	 * - Must be \<= 20 for {@link EResourceType.USER_TIMELINE}.
 	 * - Must be \<= 100 for all other cursored resources.
 	 *
@@ -39,8 +40,6 @@ export class FetchArgs {
 			EResourceType.LIST_TWEETS,
 			EResourceType.TWEET_LIKERS,
 			EResourceType.TWEET_RETWEETERS,
-			EResourceType.USER_FOLLOWERS,
-			EResourceType.USER_FOLLOWING,
 			EResourceType.USER_HIGHLIGHTS,
 			EResourceType.USER_LIKES,
 			EResourceType.USER_MEDIA,

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -101,9 +101,11 @@ export class UserService extends FetcherService {
 	 * Get the list followers of a user.
 	 *
 	 * @param id - The id of the target user.
-	 * @param count - The number of followers to fetch, must be \<= 100.
 	 * @param cursor - The cursor to the batch of followers to fetch.
 	 * @returns The list of users following the target user.
+	 *
+	 * @remarks
+	 * The first returned batch has 70 users while successive batches have 50 users each.
 	 *
 	 * @example
 	 * ```
@@ -124,13 +126,12 @@ export class UserService extends FetcherService {
 	 *
 	 * @public
 	 */
-	public async followers(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
+	public async followers(id: string, cursor?: string): Promise<CursoredData<User>> {
 		const resource = EResourceType.USER_FOLLOWERS;
 
 		// Fetching raw list of followers
 		const response = await this.request<IUserFollowersResponse>(resource, {
 			id: id,
-			count: count,
 			cursor: cursor,
 		});
 
@@ -147,6 +148,9 @@ export class UserService extends FetcherService {
 	 * @param count - The number of following to fetch, must be \<= 100.
 	 * @param cursor - The cursor to the batch of following to fetch.
 	 * @returns The list of users followed by the target user.
+	 *
+	 * @remarks
+	 * The first returned batch has 70 users while successive batches have 50 users each.
 	 *
 	 * @example
 	 * ```
@@ -167,13 +171,12 @@ export class UserService extends FetcherService {
 	 *
 	 * @public
 	 */
-	public async following(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
+	public async following(id: string, cursor?: string): Promise<CursoredData<User>> {
 		const resource = EResourceType.USER_FOLLOWING;
 
 		// Fetching raw list of following
 		const response = await this.request<IUserFollowingResponse>(resource, {
 			id: id,
-			count: count,
 			cursor: cursor,
 		});
 


### PR DESCRIPTION
The bug causes the count argument to be completely ignored. As a result, fetching user followers/followings always returns 70 user in the first batch, while successive batches have 50 users each, always.