### PR TITLE
Made FetcherService public which provides a way to access the raw response data

### DIFF
--- a/src/commands/Auth.ts
+++ b/src/commands/Auth.ts
@@ -4,7 +4,7 @@ import { output } from '../helper/CliUtils';
 import { Rettiwt } from '../Rettiwt';
 
 /**
- * Creates a new 'auht' command which uses the given Rettiwt instance.
+ * Creates a new 'auth' command which uses the given Rettiwt instance.
  *
  * @param rettiwt - The Rettiwt instance to use.
  * @returns The created 'auth' command.

--- a/src/enums/Resource.ts
+++ b/src/enums/Resource.ts
@@ -1,7 +1,7 @@
 /**
  * The different types of resources that can be interacted with.
  *
- * @internal
+ * @public
  */
 export enum EResourceType {
 	// LIST

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export * from './models/data/User';
 
 // SERVICES
 export * from './services/internal/ErrorService';
-export * from './services/internal/FetcherService';
+export * from './services/public/FetcherService';
 export * from './services/internal/LogService';
 export * from './services/public/AuthService';
 export * from './services/public/TweetService';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,14 @@
 // MAIN
 export * from './Rettiwt';
 
-// EXTERNAL
-export { TweetFilter } from 'rettiwt-core';
-
 // ENUMS
 export * from './enums/Api';
 export * from './enums/Http';
-export * from './enums/Logging';
+export * from './enums/Resource';
 
-// ERROR MODELS
-export * from './models/errors/ApiError';
-export * from './models/errors/HttpError';
-export * from './models/errors/RettiwtError';
+// ARG MODELS
+export * from './models/args/FetchArgs';
+export * from './models/args/PostArgs';
 
 // DATA MODELS
 export * from './models/data/CursoredData';
@@ -20,11 +16,16 @@ export * from './models/data/List';
 export * from './models/data/Tweet';
 export * from './models/data/User';
 
+// ERROR MODELS
+export * from './models/errors/ApiError';
+export * from './models/errors/HttpError';
+export * from './models/errors/RettiwtError';
+
 // SERVICES
 export * from './services/internal/ErrorService';
-export * from './services/public/FetcherService';
 export * from './services/internal/LogService';
 export * from './services/public/AuthService';
+export * from './services/public/FetcherService';
 export * from './services/public/TweetService';
 export * from './services/public/UserService';
 

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -20,7 +20,7 @@ import { DataValidationError } from '../errors/DataValidationError';
 /**
  * User set query parameters that are used to specify the data that is to be fetched.
  *
- * @internal
+ * @public
  */
 export class FetchArgs {
 	/**

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -28,8 +28,12 @@ export class FetchArgs {
 	 *
 	 * @remarks
 	 * - Works only for cursored resources.
-	 * - Must be \<= 20 for {@link EResourceType.USER_TIMELINE}.
+	 * - Must be \<= 20 for:
+	 * 	- {@link EResourceType.USER_TIMELINE}
+	 * 	- {@link EResourceType.USER_TIMELINE}
+	 * 	- {@link EResourceType.USER_TIMELINE_AND_REPLIES}.
 	 * - Must be \<= 100 for all other cursored resources.
+	 * - Due a bug on Twitter's end, count does not work for {@link EResourceType.USER_FOLLOWERS} and {@link EResourceType.USER_FOLLOWING}.
 	 *
 	 * @defaultValue 20
 	 */

--- a/src/models/args/PostArgs.ts
+++ b/src/models/args/PostArgs.ts
@@ -117,7 +117,7 @@ export class PostArgs {
 }
 
 /**
- * User set query parameters that are used to specify the tweet that is to be posted.
+ * Options specifying the tweet that is to be posted.
  *
  * @public
  */
@@ -176,9 +176,9 @@ export class TweetArgs extends NewTweet {
 }
 
 /**
- * User set query parameters that are used to specify the media to be posted.
+ * Options specifying the media that is to be posted.
  *
- * @internal
+ * @public
  */
 export class TweetMediaArgs extends NewTweetMedia {
 	/** The id of the media to post. */

--- a/src/models/args/PostArgs.ts
+++ b/src/models/args/PostArgs.ts
@@ -19,7 +19,7 @@ import { DataValidationError } from '../errors/DataValidationError';
 /**
  * User set query parameters that are used to specify the data that is to be posted.
  *
- * @internal
+ * @public
  */
 export class PostArgs {
 	/**

--- a/src/models/errors/ApiError.ts
+++ b/src/models/errors/ApiError.ts
@@ -3,7 +3,7 @@ import { RettiwtError } from './RettiwtError';
 /**
  * Represents an error that is thrown by Twitter API.
  *
- * @internal
+ * @public
  */
 export class ApiError extends RettiwtError {
 	/** The error code thrown by Twitter API. */

--- a/src/models/errors/HttpError.ts
+++ b/src/models/errors/HttpError.ts
@@ -3,7 +3,7 @@ import { RettiwtError } from './RettiwtError';
 /**
  * Represents an HTTP error that occues while making a request to Twitter API.
  *
- * @internal
+ * @public
  */
 export class HttpError extends RettiwtError {
 	/** The HTTP status code. */

--- a/src/models/errors/TimeoutError.ts
+++ b/src/models/errors/TimeoutError.ts
@@ -3,7 +3,7 @@ import { RettiwtError } from './RettiwtError';
 /**
  * Represents a timeout error that occues while making a request to Twitter API.
  *
- * @internal
+ * @public
  */
 export class TimeoutError extends RettiwtError {
 	/**

--- a/src/services/public/AuthService.ts
+++ b/src/services/public/AuthService.ts
@@ -1,7 +1,7 @@
 import { Auth } from 'rettiwt-auth';
 
 import { IRettiwtConfig } from '../../types/RettiwtConfig';
-import { FetcherService } from '../internal/FetcherService';
+import { FetcherService } from './FetcherService';
 
 /**
  * The services that handles authentication.

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -17,13 +17,13 @@ import { IRettiwtConfig } from '../../types/RettiwtConfig';
 
 import { AllReturnTypes } from '../../types/ReturnTypes';
 
-import { ErrorService } from './ErrorService';
-import { LogService } from './LogService';
+import { ErrorService } from '../internal/ErrorService';
+import { LogService } from '../internal/LogService';
 
 /**
  * The base service that handles all HTTP requests.
  *
- * @internal
+ * @public
  */
 export class FetcherService {
 	/** The api key to use for authenticating against Twitter API as user. */

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -22,7 +22,7 @@ import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
 import { IRettiwtConfig } from '../../types/RettiwtConfig';
-import { FetcherService } from '../internal/FetcherService';
+import { FetcherService } from './FetcherService';
 
 /**
  * Handles interacting with resources related to tweets.

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -17,7 +17,7 @@ import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
 import { IRettiwtConfig } from '../../types/RettiwtConfig';
-import { FetcherService } from '../internal/FetcherService';
+import { FetcherService } from './FetcherService';
 
 /**
  * Handles interacting with resources related to user account


### PR DESCRIPTION
The FetcherService is the class that directly interacts with the Twitter API. The TweetService and UserService classes actually use the fetcher service underneath to make requests to Twitter API, and then perform some level of post-processing of the returned response to filter out the required data.

Making the FetcherService public provides a way to get the raw response from Twitter as is, without any post processing or potential data loss. This is especially helpful for consumers who want more control over the data they receive and want to handle the data according to their own logic.

The following example demonstrates it's use in case of fetching the details of a given user:

```js
import { FetcherService, EResourceType } from 'rettiwt-api'

// Initializing a new FetcherService instance
// Note how the initialization is similar to that of the 'Rettiwt' instance
const fetcher = new FetcherService({ apiKey: API_KEY, logging: true });

// Fetching the details of the user with the username 'user1'
fetcher.request(EResourceType.USER_DETAILS_BY_USERNAME, { id: 'user1' })
.then(res => {
    console.log(res);
})
.catch(err => {
    console.log(err);
});
```

