### PR TITLE
Added query parameter for searching tweets from a list with given id

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"commander": "11.1.0",
 		"https-proxy-agent": "7.0.2",
 		"rettiwt-auth": "2.1.0",
-		"rettiwt-core": "4.3.0"
+		"rettiwt-core": "4.4.0-alpha.1"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -159,6 +159,7 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 			'Matches the tweets that do not contain any of the give comma-separated list of words',
 		)
 		.option('-h, --hashtags <string>', 'Matches the tweets containing the given comma-separated list of hashtags')
+		.option('--list <string>', 'Matches the tweets from the list with the given id')
 		.option(
 			'-m, --mentions <string>',
 			'Matches the tweets that mention the given comma-separated list of usernames',
@@ -284,6 +285,7 @@ class TweetSearchOptions {
 	public from?: string;
 	public hashtags?: string;
 	public interval?: number;
+	public list?: string;
 	public mentions?: string;
 	public minLikes?: number;
 	public minReplies?: number;
@@ -309,6 +311,7 @@ class TweetSearchOptions {
 		this.optionalWords = options?.optionalWords;
 		this.excludeWords = options?.excludeWords;
 		this.hashtags = options?.hashtags;
+		this.list = options?.list;
 		this.mentions = options?.mentions;
 		this.minReplies = options?.minReplies;
 		this.minLikes = options?.minLikes;
@@ -336,6 +339,7 @@ class TweetSearchOptions {
 			optionalWords: this.optionalWords ? this.optionalWords.split(',') : undefined,
 			excludeWords: this.excludeWords ? this.excludeWords.split(',') : undefined,
 			hashtags: this.hashtags ? this.hashtags.split(',') : undefined,
+			list: this.list,
 			mentions: this.mentions ? this.mentions.split(',') : undefined,
 			minReplies: this.minReplies,
 			minLikes: this.minLikes,

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -339,6 +339,11 @@ export class TweetFilter extends TweetFilterCore {
 	@IsBoolean()
 	public links?: boolean;
 
+	/** The list from which tweets are to be searched. */
+	@IsOptional()
+	@IsNumberString()
+	public list?: string;
+
 	/** The id of the tweet, before which the tweets are to be searched. */
 	@IsOptional()
 	@IsNumberString()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,7 +2743,7 @@ __metadata:
     nodemon: "npm:2.0.20"
     prettier: "npm:3.0.0"
     rettiwt-auth: "npm:2.1.0"
-    rettiwt-core: "npm:4.3.0"
+    rettiwt-core: "npm:4.4.0-alpha.1"
     typedoc: "npm:0.24.8"
     typescript: "npm:5.1.6"
   bin:
@@ -2765,13 +2765,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rettiwt-core@npm:4.3.0":
-  version: 4.3.0
-  resolution: "rettiwt-core@npm:4.3.0"
+"rettiwt-core@npm:4.4.0-alpha.1":
+  version: 4.4.0-alpha.1
+  resolution: "rettiwt-core@npm:4.4.0-alpha.1"
   dependencies:
     axios: "npm:1.6.3"
     form-data: "npm:4.0.0"
-  checksum: 10c0/d81adf975057c45142d01cfd244589787b1a275d18d6d31a1d0dfe5499524aac54528ba3910b81a6e1cdf17ce73bde4ae275659b1dbf50e839b5888a09e9d4c1
+  checksum: 10c0/108c4e254c43aeae8258dc4c02df37e2b9fb9305d8cf7c3aa1e849a441485c1a09e1b6d3d80a158a9f3c6aec0ec44e3283c358974c3cf778041542e69e55548c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Searching from lists can now be accomplished by using the `list` `TweetFilter` parameters, as demonstrated below:

```ts
import { Rettiwt } from 'rettiwt-api';

// Initialzing new Rettiwt instance
const rettiwt: Rettiwt = new Rettiwt({ apiKey: '<API_KEY>' });

// Searching the most recent 10 tweets from a list with id '1234567890', excluding replies
rettiwt.tweet.search({ list: "1234567890", replies: false }, 10).then(res => console.log(res)).catch(err => console.log(err));
```