### PR TITLE
Added functionality to fetch either latest or top results using tweet search

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"commander": "11.1.0",
 		"https-proxy-agent": "7.0.2",
 		"rettiwt-auth": "2.1.0",
-		"rettiwt-core": "4.4.0-alpha.1"
+		"rettiwt-core": "4.4.0-alpha.2"
 	},
 	"devDependencies": {
 		"@types/node": "20.4.1",

--- a/src/collections/Requests.ts
+++ b/src/collections/Requests.ts
@@ -32,7 +32,7 @@ export const requests: { [key in keyof typeof EResourceType]: (args: FetchArgs |
 	TWEET_RETWEET: (args: PostArgs) => request.tweet.retweet(args.id!),
 	TWEET_RETWEETERS: (args: FetchArgs) => request.tweet.retweeters(args.id!, args.count, args.cursor),
 	TWEET_SCHEDULE: (args: PostArgs) => request.tweet.schedule(args.tweet!, args.tweet!.scheduleFor!),
-	TWEET_SEARCH: (args: FetchArgs) => request.tweet.search(args.filter!, args.count, args.cursor),
+	TWEET_SEARCH: (args: FetchArgs) => request.tweet.search(args.filter!, args.count, args.cursor, args.results),
 	TWEET_UNLIKE: (args: PostArgs) => request.tweet.unlike(args.id!),
 	TWEET_UNPOST: (args: PostArgs) => request.tweet.unpost(args.id!),
 	TWEET_UNRETWEET: (args: PostArgs) => request.tweet.unretweet(args.id!),

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -1,5 +1,5 @@
 import { Command, createCommand } from 'commander';
-import { TweetFilter } from 'rettiwt-core';
+import { ESearchResultType, TweetFilter } from 'rettiwt-core';
 
 import { output } from '../helper/CliUtils';
 import { Rettiwt } from '../Rettiwt';
@@ -172,6 +172,7 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.option('--exclude-replies', 'Matches the tweets that are not replies')
 		.option('-s, --start <string>', 'Matches the tweets made since the given date (valid date/time string)')
 		.option('-e, --end <string>', 'Matches the tweets made upto the given date (valid date/time string)')
+		.option('--top', 'Matches top tweets instead of latest')
 		.option('--stream', 'Stream the filtered tweets in pseudo-realtime')
 		.option('-i, --interval <number>', 'The polling interval (in ms) to use for streaming. Default is 60000')
 		.action(async (count?: string, cursor?: string, options?: TweetSearchOptions) => {
@@ -191,6 +192,7 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 						new TweetSearchOptions(options).toTweetFilter(),
 						count ? parseInt(count) : undefined,
 						cursor,
+						options?.top ? ESearchResultType.TOP : ESearchResultType.LATEST,
 					);
 					output(tweets);
 				}
@@ -296,6 +298,7 @@ class TweetSearchOptions {
 	public start?: string;
 	public stream?: boolean;
 	public to?: string;
+	public top?: boolean;
 	public words?: string;
 
 	/**
@@ -323,6 +326,7 @@ class TweetSearchOptions {
 		this.end = options?.end;
 		this.stream = options?.stream;
 		this.interval = options?.interval;
+		this.top = options?.top;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './Rettiwt';
 export * from './enums/Api';
 export * from './enums/Http';
 export * from './enums/Resource';
+export { ESearchResultType } from 'rettiwt-core';
 
 // ARG MODELS
 export * from './models/args/FetchArgs';

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -14,7 +14,7 @@ import {
 	validateSync,
 } from 'class-validator';
 
-import { TweetFilter as TweetFilterCore } from 'rettiwt-core';
+import { ESearchResultType, TweetFilter as TweetFilterCore } from 'rettiwt-core';
 
 import { EResourceType } from '../../enums/Resource';
 import { DataValidationError } from '../errors/DataValidationError';
@@ -256,6 +256,40 @@ export class FetchArgs {
 	public id?: string;
 
 	/**
+	 * The type of search results to fetch. Can be one of:
+	 * - {@link EResourceType.LATEST}, for latest search results.
+	 * - {@link EResourceType.TOP}, for top search results.
+	 *
+	 * @defaultValue {@link ESearchResultType.LATEST}.
+	 *
+	 * @remarks
+	 * - Applicable only for {@link EResourceType.TWEET_SEARCH}.
+	 */
+	@IsEmpty({
+		groups: [
+			EResourceType.LIST_TWEETS,
+			EResourceType.TWEET_DETAILS,
+			EResourceType.TWEET_DETAILS_ALT,
+			EResourceType.TWEET_RETWEETERS,
+			EResourceType.USER_DETAILS_BY_USERNAME,
+			EResourceType.USER_DETAILS_BY_ID,
+			EResourceType.USER_FEED_FOLLOWED,
+			EResourceType.USER_FEED_RECOMMENDED,
+			EResourceType.USER_FOLLOWING,
+			EResourceType.USER_FOLLOWERS,
+			EResourceType.USER_HIGHLIGHTS,
+			EResourceType.USER_LIKES,
+			EResourceType.USER_MEDIA,
+			EResourceType.USER_NOTIFICATIONS,
+			EResourceType.USER_SUBSCRIPTIONS,
+			EResourceType.USER_TIMELINE,
+			EResourceType.USER_TIMELINE_AND_REPLIES,
+		],
+	})
+	@IsOptional({ groups: [EResourceType.TWEET_SEARCH] })
+	public results?: ESearchResultType;
+
+	/**
 	 * @param resource - The resource to be fetched.
 	 * @param args - Additional user-defined arguments for fetching the resource.
 	 */
@@ -264,6 +298,7 @@ export class FetchArgs {
 		this.count = args.count;
 		this.cursor = args.cursor;
 		this.filter = args.filter ? new TweetFilter(args.filter) : undefined;
+		this.results = args.results ?? ESearchResultType.LATEST;
 
 		// Validating this object
 		const validationResult = validateSync(this, { groups: [resource] });

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -1,6 +1,7 @@
 import { statSync } from 'fs';
 
 import {
+	ESearchResultType,
 	IInitializeMediaUploadResponse,
 	IListTweetsResponse,
 	ITweetDetailsResponse,
@@ -398,6 +399,7 @@ export class TweetService extends FetcherService {
 	 * @param filter - The filter to be used for searching the tweets.
 	 * @param count - The number of tweets to fetch, must be \<= 20.
 	 * @param cursor - The cursor to the batch of tweets to fetch.
+	 * @param results - The type of search results to fetch. Default is {@link ESearchResultType.LATEST}.
 	 *
 	 * @returns The list of tweets that match the given filter.
 	 *
@@ -420,7 +422,12 @@ export class TweetService extends FetcherService {
 	 *
 	 * @remarks For details about available filters, refer to {@link TweetFilter}
 	 */
-	public async search(filter: TweetFilter, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
+	public async search(
+		filter: TweetFilter,
+		count?: number,
+		cursor?: string,
+		results?: ESearchResultType,
+	): Promise<CursoredData<Tweet>> {
 		const resource = EResourceType.TWEET_SEARCH;
 
 		// Fetching raw list of filtered tweets
@@ -428,6 +435,7 @@ export class TweetService extends FetcherService {
 			filter: filter,
 			count: count,
 			cursor: cursor,
+			results: results,
 		});
 
 		// Deserializing response

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,7 +2743,7 @@ __metadata:
     nodemon: "npm:2.0.20"
     prettier: "npm:3.0.0"
     rettiwt-auth: "npm:2.1.0"
-    rettiwt-core: "npm:4.4.0-alpha.1"
+    rettiwt-core: "npm:4.4.0-alpha.2"
     typedoc: "npm:0.24.8"
     typescript: "npm:5.1.6"
   bin:
@@ -2765,13 +2765,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rettiwt-core@npm:4.4.0-alpha.1":
-  version: 4.4.0-alpha.1
-  resolution: "rettiwt-core@npm:4.4.0-alpha.1"
+"rettiwt-core@npm:4.4.0-alpha.2":
+  version: 4.4.0-alpha.2
+  resolution: "rettiwt-core@npm:4.4.0-alpha.2"
   dependencies:
     axios: "npm:1.6.3"
     form-data: "npm:4.0.0"
-  checksum: 10c0/108c4e254c43aeae8258dc4c02df37e2b9fb9305d8cf7c3aa1e849a441485c1a09e1b6d3d80a158a9f3c6aec0ec44e3283c358974c3cf778041542e69e55548c
+  checksum: 10c0/7cb62f9f8077cc8785c30d44ae3bf3ed8f35802df7ac6b3b1fff862847b8b21038d988694ec2fc970f25e50ad164050ff1cba5824d2614df88d1db1cacf94698
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This can be done by using an additional filter in `TweetFilter` while searching for tweets. If not set explicity, latest results are fetched, else top results are fetched.

```ts
import { Rettiwt } from 'rettiwt-api';

// Creating a new Rettiwt instance
const rettiwt = new Rettiwt({ logging: true, apiKey: '<API_KEY>' };

// Searching for top tweets from user 'user1', with a count of 10 and no cursor
/**
 * If you omit the 'top: true' parameter, default of latest will be searched.
 */
rettiwt.tweet.search({ fromUsers: ['user1'] , top: true })
    .then(res => {
        console.log(res);
    })
    catch(err => {
        console.log(err);
    });
```