### PR TITLE
fix: do not include automated account to User.single method

### DIFF
--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -123,7 +123,7 @@ export class User {
 
 		// Deserializing valid data
 		for (const item of extract) {
-			if (item.legacy) {
+			if (item.legacy && item.legacy.created_at) {
 				// Logging
 				LogService.log(ELogActions.DESERIALIZE, { id: item.rest_id });
 


### PR DESCRIPTION
I described most of the issue in that [PR](https://github.com/Rishikant181/Rettiwt-Core/pull/201)

However it seems we need to make a fix here.

It will help us to exclude unnecessary user creation and omit issue when we trying to access some properties in User model that doesn't exists in `extract` data
