### PR TITLE
Added support for custom headers

### DIFF
--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -46,6 +46,9 @@ export class FetcherService {
 	/** The id of the authenticated user (if any). */
 	protected readonly userId?: string;
 
+	/** Custom headers to use for all requests */
+	private readonly _customHeaders?: { [key: string]: string };
+
 	/**
 	 * @param config - The config object for configuring the Rettiwt instance.
 	 */
@@ -58,6 +61,7 @@ export class FetcherService {
 		this._proxyUrl = config?.proxyUrl;
 		this._timeout = config?.timeout ?? 0;
 		this._errorHandler = config?.errorHandler ?? new ErrorService();
+		this._customHeaders = config?.headers;
 	}
 
 	/**
@@ -192,7 +196,7 @@ export class FetcherService {
 		const config = requests[resource](args);
 
 		// Setting additional request parameters
-		config.headers = { ...config.headers, ...cred.toHeader() };
+		config.headers = { ...config.headers, ...cred.toHeader(), ...(this._customHeaders || {}) };
 		config.httpAgent = httpsAgent;
 		config.httpsAgent = httpsAgent;
 		config.timeout = this._timeout;

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -36,4 +36,11 @@ export interface IRettiwtConfig {
 
 	/** Optional custom error handler to define error conditions and process API/HTTP errors in responses. */
 	errorHandler?: IErrorHandler;
+
+	/**
+	* Optional custom HTTP headers to add to all requests to Twitter API.
+	* 
+	* @remarks Custom headers can be useful for proxies, avoiding rate limits, etc.
+	*/
+	headers?: { [key: string]: string };
 }


### PR DESCRIPTION
Added a string key - string value header property to the IRettiwtConfig interface and the FetcherService class.
The custom headers, if they exist, are then combined with the existing headers in the request method of the FetcherService class.

Regarding error handling, I think we can let the user manage the validity of the custom headers they decide to add.