### PR TITLE
Simplified cursor to a simple string instead of an object

### DIFF
--- a/src/models/data/CursoredData.ts
+++ b/src/models/data/CursoredData.ts
@@ -2,7 +2,7 @@ import { EBaseType } from '../../enums/Data';
 
 import { findByFilter } from '../../helper/JsonUtils';
 
-import { ICursor, ICursoredData } from '../../types/data/CursoredData';
+import { ICursoredData } from '../../types/data/CursoredData';
 import { ICursor as IRawCursor } from '../../types/raw/base/Cursor';
 
 import { Notification } from './Notification';
@@ -17,8 +17,8 @@ import { User } from './User';
  * @public
  */
 export class CursoredData<T extends Notification | Tweet | User> implements ICursoredData<T> {
-	public list: T[] = [];
-	public next: Cursor = new Cursor('');
+	public list: T[];
+	public next: string;
 
 	/**
 	 * @param response - The raw response.
@@ -27,34 +27,17 @@ export class CursoredData<T extends Notification | Tweet | User> implements ICur
 	public constructor(response: NonNullable<unknown>, type: EBaseType) {
 		// Initializing defaults
 		this.list = [];
-		this.next = new Cursor('');
+		this.next = '';
 
 		if (type == EBaseType.TWEET) {
 			this.list = Tweet.list(response) as T[];
-			this.next = new Cursor(findByFilter<IRawCursor>(response, 'cursorType', 'Bottom')[0]?.value ?? '');
+			this.next = findByFilter<IRawCursor>(response, 'cursorType', 'Bottom')[0]?.value ?? '';
 		} else if (type == EBaseType.USER) {
 			this.list = User.list(response) as T[];
-			this.next = new Cursor(findByFilter<IRawCursor>(response, 'cursorType', 'Bottom')[0]?.value ?? '');
+			this.next = findByFilter<IRawCursor>(response, 'cursorType', 'Bottom')[0]?.value ?? '';
 		} else if (type == EBaseType.NOTIFICATION) {
 			this.list = Notification.list(response) as T[];
-			this.next = new Cursor(findByFilter<IRawCursor>(response, 'cursorType', 'Top')[0]?.value ?? '');
+			this.next = findByFilter<IRawCursor>(response, 'cursorType', 'Top')[0]?.value ?? '';
 		}
-	}
-}
-
-/**
- * The cursor to the batch of data to fetch.
- *
- * @public
- */
-export class Cursor implements ICursor {
-	/** The cursor string. */
-	public value: string;
-
-	/**
-	 * @param cursor - The cursor string.
-	 */
-	public constructor(cursor: string) {
-		this.value = cursor;
 	}
 }

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -537,7 +537,7 @@ export class TweetService extends FetcherService {
 
 			// If there are more tweets to fetch, adjust the cursor value
 			if (tweets.list.length > 0 && tweets.next) {
-				cursor = tweets.next.value;
+				cursor = tweets.next;
 			}
 			// Else, start the next iteration from this batch's most recent tweet
 			else {

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -499,7 +499,7 @@ export class UserService extends FetcherService {
 				first = false;
 			}
 
-			cursor = notifications.next.value;
+			cursor = notifications.next;
 		}
 	}
 

--- a/src/types/data/CursoredData.ts
+++ b/src/types/data/CursoredData.ts
@@ -14,15 +14,5 @@ export interface ICursoredData<T extends INotification | ITweet | IUser> {
 	list: T[];
 
 	/** The cursor to the next batch of data. */
-	next: ICursor;
-}
-
-/**
- * The cursor to the batch of data to fetch.
- *
- * @public
- */
-export interface ICursor {
-	/** The cursor string. */
-	value: string;
+	next: string;
 }


### PR DESCRIPTION
The cursor of `CursoredData` is now simplified to a string instead of a `Cursor` object.

Earlier:
`CursoredData.next` -> `Cursor`

Now:
`CursoredData.next` -> `string`