### PR TITLE
Added ability to set a delay between concurrent requests

### DIFF
--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -43,4 +43,11 @@ export interface IRettiwtConfig {
 	 * @remarks Custom headers can be useful for proxies, avoiding rate limits, etc.
 	 */
 	headers?: { [key: string]: string };
+
+	/**
+	 * The delay (in ms) to use between concurrent request.
+	 *
+	 * Can either be a number or a function that returns a number synchronously or asynchronously.
+	 */
+	delay?: number | (() => number | Promise<number>);
 }


### PR DESCRIPTION
The delay (in milliseconds) can be a number or a function (synchronous or asynchronous) that returns the delay (in milliseconds), as follows:

1. Delay as a number:

```ts
// Using a delay of 1000 milliseconds
const rettiwt = new Rettiwt({ apiKey: "<API_KEY>", delay: 1000 });
```

2. Delay as a function

```ts
// Using a function which returns a random delay between 0 and 10000 milliseconds
const rettiwt = new Rettiwt({ apiKey: "<API_KEY>", delay: () = (Math.random() * 10000) });
```