### PR TITLE
Add x-client-transaction-id generation script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
 				"chalk": "5.4.1",
 				"commander": "13.1.0",
 				"cookiejar": "2.1.4",
-				"https-proxy-agent": "7.0.6"
+				"https-proxy-agent": "7.0.6",
+				"node-html-parser": "7.0.1"
 			},
 			"bin": {
 				"rettiwt": "dist/cli.js"
@@ -923,6 +924,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
+		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1124,6 +1131,34 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
 		"node_modules/data-view-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -1260,6 +1295,61 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1278,7 +1368,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -2264,6 +2353,15 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -2977,6 +3075,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/node-html-parser": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+			"integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+			"license": "MIT",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"he": "1.2.0"
+			}
+		},
 		"node_modules/nodemon": {
 			"version": "3.1.9",
 			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
@@ -3038,6 +3146,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
 		"node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"chalk": "5.4.1",
 		"commander": "13.1.0",
 		"cookiejar": "2.1.4",
-		"https-proxy-agent": "7.0.6"
+		"https-proxy-agent": "7.0.6",
+		"node-html-parser": "7.0.1"
 	}
 }

--- a/src/Rettiwt.ts
+++ b/src/Rettiwt.ts
@@ -1,4 +1,5 @@
 import { AuthService } from './services/internal/AuthService';
+import { TransactionIdService } from './services/internal/TidService';
 import { ListService } from './services/public/ListService';
 import { TweetService } from './services/public/TweetService';
 import { UserService } from './services/public/UserService';
@@ -64,9 +65,10 @@ export class Rettiwt {
 	 * @param config - The config object for configuring the Rettiwt instance.
 	 */
 	public constructor(config?: IRettiwtConfig) {
-		this.auth = new AuthService(config);
-		this.list = new ListService(config);
-		this.tweet = new TweetService(config);
-		this.user = new UserService(config);
+		const tidProvider = config?.tidProvider ?? new TransactionIdService();
+		this.auth = new AuthService({ ...config, tidProvider });
+		this.list = new ListService({ ...config, tidProvider });
+		this.tweet = new TweetService({ ...config, tidProvider });
+		this.user = new UserService({ ...config, tidProvider });
 	}
 }

--- a/src/helper/TidUtils.ts
+++ b/src/helper/TidUtils.ts
@@ -24,7 +24,7 @@ export interface IGenerateTransactionIdParams {
 }
 
 export function calculateClientTransactionIdHeader(args: IGenerateTransactionIdParams): string {
-	const time = args.time || Math.floor((Date.now() - 1682924400 * 1000) / 1000);
+	const time = Math.floor(((args.time || Date.now()) - 1682924400 * 1000) / 1000);
 	const timeBuffer = new Uint8Array(new Uint32Array([time]).buffer);
 
 	const keyBytes = Array.from(Buffer.from(args.verificationKey, 'base64'));

--- a/src/helper/TidUtils.ts
+++ b/src/helper/TidUtils.ts
@@ -1,0 +1,207 @@
+import { createHash } from 'node:crypto';
+
+export interface IGenerateTransactionIdParams {
+	/** Secret used for transaction ID calculation. */
+	keyword: string;
+	/** Request method. */
+	method: string;
+	/** Endpoint path without query parameters. */
+	path: string;
+	/** Twitter verification key received from HTML. */
+	verificationKey: string;
+	/** Animation frames extracted from HTML. */
+	frames: number[][][];
+	/** Indices used for getting the correct verification key bytes during animation key calculation. */
+	indices: number[];
+	/** Final byte of the transaction ID. */
+	extraByte: number;
+	/** Current time */
+	time?: number;
+	/** XOR byte used for final hash calculation, must be in 0-255 range. */
+	xorByte?: number;
+	/** Precomputed animation key. */
+	animationKey?: string;
+}
+
+export function calculateClientTransactionIdHeader(args: IGenerateTransactionIdParams): string {
+	const time = args.time || Math.floor((Date.now() - 1682924400 * 1000) / 1000);
+	const timeBuffer = new Uint8Array(new Uint32Array([time]).buffer);
+
+	const keyBytes = Array.from(Buffer.from(args.verificationKey, 'base64'));
+	const animationKey = args.animationKey || getAnimationKey(keyBytes, args.frames, args.indices);
+
+	const value = [args.method, args.path, time].join('!') + args.keyword + animationKey;
+	const valueEncoded = new TextEncoder().encode(value);
+
+	const hash = createHash('sha-256').update(valueEncoded).digest();
+	const hashBytes = Array.from(new Uint8Array(hash));
+
+	const xorByte = args.xorByte || Math.floor(Math.random() * 256);
+
+	const bytes = new Uint8Array(keyBytes.concat(Array.from(timeBuffer), hashBytes.slice(0, 16), [args.extraByte]));
+	return encode(xor(xorByte, bytes));
+}
+
+function getAnimationKey(keyBytes: number[], frames: number[][][], indices: number[]): string {
+	const totalTime = 4096;
+	const rowIndex = keyBytes[indices[0]] % 16;
+	const frameTime = indices.slice(1).map((idx) => keyBytes[idx] % 16).reduce((a, b) => a * b, 1);
+	const targetTime = frameTime / totalTime;
+	const frameRow = frames[keyBytes[5] % 4][rowIndex];
+	return animate(frameRow, targetTime);
+}
+
+function animate(frameRow: number[], targetTime: number): string {
+	const curves = frameRow.slice(7).map((v, i) => Number(a(v, b(i), 1).toFixed(2)));
+	const cubicValue = getCubicCurveValue(curves, targetTime);
+
+	const fromColor = [...frameRow.slice(0, 3), 1];
+	const toColor = [...frameRow.slice(3, 6), 1];
+	const color = interpolate(fromColor, toColor, cubicValue);
+
+	const fromRotation = [0];
+	const toRotation = [Math.floor(a(frameRow[6], 60, 360))];
+	const rotation = interpolate(fromRotation, toRotation, cubicValue);
+	const matrix = convertRotationToMatrix(rotation[0]);
+
+	const strArray: string[] = [];
+	for (let i = 0; i < color.length - 1; i++) {
+		strArray.push(Math.round(color[i]).toString(16));
+	}
+
+	for (let i = 0; i < matrix.length; i++) {
+		let rounded = Number(matrix[i].toFixed(2));
+		if (rounded < 0) {
+			rounded = -rounded;
+		}
+		const hexValue = floatToHex(rounded);
+		if (hexValue.startsWith('.')) {
+			strArray.push('0' + hexValue);
+		} else if (hexValue) {
+			strArray.push(hexValue);
+		} else {
+			strArray.push('0');
+		}
+	}
+
+	strArray.push('0', '0');
+	return strArray.join('').replace(/[.-]/g, '').toLowerCase();
+}
+
+function a(b: number, c: number, d: number): number {
+	return (b * (d - c)) / 255 + c;
+}
+
+function b(a: number): number {
+	return a % 2 === 1 ? -1 : 0;
+}
+
+function getCubicCurveValue(curves: number[], time: number): number {
+	let startGradient = 0;
+	let endGradient = 0;
+
+	if (time <= 0) {
+		if (curves[0] > 0) {
+			startGradient = curves[1] / curves[0];
+		} else if (curves[1] === 0 && curves[2] > 0) {
+			startGradient = curves[3] / curves[2];
+		}
+		return startGradient * time;
+	}
+
+	if (time >= 1) {
+		if (curves[2] < 1) {
+			endGradient = (curves[3] - 1) / (curves[2] - 1);
+		} else if (curves[2] === 1 && curves[0] < 1) {
+			endGradient = (curves[1] - 1) / (curves[0] - 1);
+		}
+		return 1 + endGradient * (time - 1);
+	}
+
+	let start = 0;
+	let end = 1;
+	let mid = 0;
+
+	while (start < end) {
+		mid = (start + end) / 2;
+		const xEst = calculateBezier(curves[0], curves[2], mid);
+		if (Math.abs(time - xEst) < 0.00001) {
+			return calculateBezier(curves[1], curves[3], mid);
+		}
+		if (xEst < time) {
+			start = mid;
+		} else {
+			end = mid;
+		}
+	}
+
+	return calculateBezier(curves[1], curves[3], mid);
+}
+
+function calculateBezier(a: number, b: number, m: number): number {
+	return 3 * a * (1 - m) * (1 - m) * m + 3 * b * (1 - m) * m * m + m * m * m;
+}
+
+function interpolate(from: number[], to: number[], f: number): number[] {
+	const out: number[] = [];
+	for (let i = 0; i < from.length; i++) {
+		out.push(from[i] * (1 - f) + to[i] * f);
+	}
+	return out;
+}
+
+function convertRotationToMatrix(degrees: number): number[] {
+	const radians = (degrees * Math.PI) / 180;
+	const c = Math.cos(radians);
+	const s = Math.sin(radians);
+	return [c, -s, s, c];
+}
+
+function floatToHex(x: number): string {
+	const result: string[] = [];
+	let quotient = Math.floor(x);
+	let fraction = x - quotient;
+
+	while (quotient > 0) {
+		const remainder = quotient % 16;
+		quotient = Math.floor(quotient / 16);
+
+		if (remainder > 9) {
+			result.unshift(String.fromCharCode(remainder + 55));
+		} else {
+			result.unshift(remainder.toString());
+		}
+	}
+
+	if (fraction === 0) {
+		return result.join('');
+	}
+
+	result.push('.');
+
+	while (fraction > 0) {
+		fraction *= 16;
+		const integer = Math.floor(fraction);
+		fraction -= integer;
+
+		if (integer > 9) {
+			result.push(String.fromCharCode(integer + 55));
+		} else {
+			result.push(integer.toString());
+		}
+	}
+
+	return result.join('');
+}
+
+function xor(xorByte: number, data: Uint8Array): Uint8Array {
+	return new Uint8Array([xorByte, ...data.map((v) => v ^ xorByte)]);
+}
+
+function encode(data: Uint8Array): string {
+	return btoa(
+		Array.from(data)
+			.map((v) => String.fromCharCode(v))
+			.join(''),
+	).replaceAll('=', '');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export * from './requests/User';
 
 // SERVICES
 export * from './services/internal/AuthService';
+export * from './services/internal/TidService';
 export * from './services/public/FetcherService';
 export * from './services/public/ListService';
 export * from './services/public/TweetService';

--- a/src/services/internal/AuthService.ts
+++ b/src/services/internal/AuthService.ts
@@ -6,6 +6,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import { EApiErrors } from '../../enums/Api';
 import { AuthCredential } from '../../models/auth/AuthCredential';
+import { TidProvider } from '../../types/auth/TidProvider';
 import { IRettiwtConfig } from '../../types/RettiwtConfig';
 
 /**
@@ -17,11 +18,15 @@ export class AuthService {
 	/** The HTTPS Agent to use for requests to Twitter API. */
 	private readonly _httpsAgent: Agent;
 
+	/** Optional custom `x-client-transaction-id` header provider. */
+	private readonly _tidProvider?: TidProvider;
+
 	/**
 	 * @param config - The config object for configuring the `Rettiwt` instance.
 	 */
 	public constructor(config?: IRettiwtConfig) {
 		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config.proxyUrl) : new https.Agent();
+		this._tidProvider = config?.tidProvider
 	}
 
 	/**
@@ -117,5 +122,11 @@ export class AuthService {
 			});
 
 		return cred;
+	}
+
+	public async refreshTidDynamicArgs(): Promise<void> {
+		if (this._tidProvider) {
+			await this._tidProvider.refreshDynamicArgs()
+		}
 	}
 }

--- a/src/services/internal/TidService.ts
+++ b/src/services/internal/TidService.ts
@@ -1,0 +1,94 @@
+import axios from 'axios';
+import * as htmlParser from 'node-html-parser';
+
+import { ELogActions } from '../../enums/Logging';
+
+import { calculateClientTransactionIdHeader, IGenerateTransactionIdParams } from '../../helper/TidUtils';
+
+import { TidProvider } from '../../types/auth/TidProvider';
+
+import { LogService } from './LogService';
+
+
+const cdnUrl = 'https://abs.twimg.com/responsive-web/client-web'
+const initialRequestHeaders = {
+	"Authority": "x.com",
+	"Accept-Language": "en-US,en;q=0.9",
+	"Cache-Control": "no-cache",
+	"Referer": "https://x.com",
+	"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
+	"X-Twitter-Active-User": "yes",
+	"X-Twitter-Client-Language": "en"
+}
+
+type DynamicArgs = Pick<IGenerateTransactionIdParams, 'verificationKey' | 'frames' | 'indices'>
+
+export class TransactionIdService implements TidProvider {
+	private _dynamicArgs?: DynamicArgs
+
+	private async getDynamicArgs(): Promise<DynamicArgs> {
+		const html = await this.getHomepageHtml()
+
+		const root = htmlParser.parse(html)
+		const keyElement = root.querySelector("[name='twitter-site-verification']")
+		const frameElements = root.querySelectorAll("[id^='loading-x-anim']")
+
+		return {
+			verificationKey: keyElement?.getAttribute('content') ?? '',
+			frames: frameElements.map((el) => this.parseFrameElement(el)),
+			indices: await this.getKeyBytesIndices(html),
+		}
+	}
+
+	private async getHomepageHtml(): Promise<string> {
+		const response = await axios.get<string>('https://x.com', { headers: initialRequestHeaders })
+		return response.data
+	}
+
+	private async getKeyBytesIndices(html: string): Promise<number[]> {
+		const ondemandFileMatch = html.match(/ondemand\.s":"([^"]+)"/)
+		if (!ondemandFileMatch || !ondemandFileMatch[1]) {
+			LogService.log(ELogActions.WARNING, {message: 'ondemand.s file not found'})
+			return [0, 0, 0, 0]
+		}
+
+		const onDemandFileHash = ondemandFileMatch ? ondemandFileMatch[1] : ''
+		const response = await axios.get<string>(`${cdnUrl}/ondemand.s.${onDemandFileHash}a.js`)
+		const match = response.data.matchAll(/(\(\w\[(\d{1,2})],\s*16\))+?/gm)
+		return Array.from(match).map(m => Number(m[2]))
+	}
+
+	private parseFrameElement(element: htmlParser.HTMLElement): number[][] {
+		const pathElement = element.children[0].children[1]
+		const value = pathElement.getAttribute('d')
+		if (!value) {
+			return [[]]
+		}
+
+		const rawFrames = value.substring(9).split('C')
+		return rawFrames
+			.map((str) => str.replaceAll(/\D+/g, ' ').trim().split(' '))
+			.map((arr) => arr.map(Number))
+	}
+
+	public async generate(method: string, path: string): Promise<string> {
+		if (!this._dynamicArgs) {
+			this._dynamicArgs = await this.getDynamicArgs()
+		}
+
+		const {verificationKey, frames, indices} = this._dynamicArgs
+		return calculateClientTransactionIdHeader({
+			keyword: 'obfiowerehiring',
+			method: method,
+			path: path,
+			verificationKey: verificationKey,
+			frames: frames,
+			indices: indices,
+			extraByte: 3,
+		})
+	}
+
+	public async refreshDynamicArgs(): Promise<void> {
+		this._dynamicArgs = await this.getDynamicArgs()
+	}
+}

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -1,3 +1,4 @@
+import { TidProvider } from './auth/TidProvider';
 import { IErrorHandler } from './ErrorHandler';
 
 /**
@@ -36,6 +37,9 @@ export interface IRettiwtConfig {
 
 	/** Optional custom error handler to define error conditions and process API/HTTP errors in responses. */
 	errorHandler?: IErrorHandler;
+
+	/** Optional custom `x-client-transaction-id` header provider. */
+	tidProvider?: TidProvider;
 
 	/**
 	 * Optional custom HTTP headers to add to all requests to Twitter API.

--- a/src/types/auth/TidProvider.ts
+++ b/src/types/auth/TidProvider.ts
@@ -1,0 +1,17 @@
+/**
+ * Service responsible for generating the `x-client-transaction-id` header.
+ */
+export interface TidProvider {
+	/**
+	 * Generates new `x-client-transaction-id` header.
+	 *
+	 * @param method - Request method.
+	 * @param path - Endpoint path without query parameters.
+	 */
+	generate(method: string, path: string): Promise<string>;
+
+	/**
+	 * Refresh arguments obtained from parsing the HTML page, if any.
+	 */
+	refreshDynamicArgs(): Promise<void>
+}


### PR DESCRIPTION
Gm :wave: I've spent some time on porting the `x-client-transaction-id` generation scripts from other languages to TS and wanted to contribute here.

Unfortunately, all the scripts I've tried (including one in this PR) aren't working 100% of the time, and I don't exactly know why - might be because some specific combination of inputs result in an invalid header, but not sure. Based on my tests it calculates a valid header ~75% of the time - which, could be worse - but ofc it's far from stable.

That's why, imo, some retry logic is needed to recompute the dynamic parts of the algorithm on the `NOT_FOUND` errors, but I'm not exactly sure how to implement this logic here without breaking anything. Instead I decided to just expose a `refreshTidDynamicArgs(...)` function, so anybody using the client can handle the refresh on their own for now.

You're welcome to move the code around if you think it should be placed somewhere else or in a different manner :saluting_face: 