### PR TITLE
Some config options are now hot-swappable

### DIFF
--- a/src/Rettiwt.ts
+++ b/src/Rettiwt.ts
@@ -69,4 +69,19 @@ export class Rettiwt {
 		this.tweet = new TweetService(this._config);
 		this.user = new UserService(this._config);
 	}
+
+	/** Set the API key for the current instance. */
+	public set apiKey(apiKey: string | undefined) {
+		this._config.apiKey = apiKey;
+	}
+
+	/** Set the custom headers for the current instance. */
+	public set headers(headers: { [key: string]: string }) {
+		this._config.headers = headers;
+	}
+
+	/** Set the proxy URL for the current instance. */
+	public set proxyUrl(proxyUrl: URL) {
+		this._config.proxyUrl = proxyUrl;
+	}
 }

--- a/src/Rettiwt.ts
+++ b/src/Rettiwt.ts
@@ -1,3 +1,4 @@
+import { RettiwtConfig } from './models/RettiwtConfig';
 import { ListService } from './services/public/ListService';
 import { TweetService } from './services/public/TweetService';
 import { UserService } from './services/public/UserService';
@@ -45,6 +46,9 @@ import { IRettiwtConfig } from './types/RettiwtConfig';
  * @public
  */
 export class Rettiwt {
+	/** The configuration for Rettiwt. */
+	private _config: RettiwtConfig;
+
 	/** The instance used to fetch data related to lists. */
 	public list: ListService;
 
@@ -60,8 +64,9 @@ export class Rettiwt {
 	 * @param config - The config object for configuring the Rettiwt instance.
 	 */
 	public constructor(config?: IRettiwtConfig) {
-		this.list = new ListService(config);
-		this.tweet = new TweetService(config);
-		this.user = new UserService(config);
+		this._config = new RettiwtConfig(config);
+		this.list = new ListService(this._config);
+		this.tweet = new TweetService(this._config);
+		this.user = new UserService(this._config);
 	}
 }

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -26,17 +26,17 @@ export class RettiwtConfig implements IRettiwtConfig {
 	/**
 	 * @param config - The config for Rettiwt of type {@link IRettiwtConfig}.
 	 */
-	public constructor(config: IRettiwtConfig) {
-		this._apiKey = config.apiKey;
-		this._httpsAgent = config.proxyUrl ? new HttpsProxyAgent(config.proxyUrl) : new Agent();
-		this._userId = config.apiKey ? AuthService.getUserId(config.apiKey) : undefined;
-		this.delay = config.delay;
-		this.errorHandler = config.errorHandler;
-		this.logging = config.logging;
-		this.tidProvider = config.tidProvider;
-		this.timeout = config.timeout;
-		this.apiKey = config.apiKey;
-		this.headers = config.headers;
+	public constructor(config?: IRettiwtConfig) {
+		this._apiKey = config?.apiKey;
+		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
+		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
+		this.delay = config?.delay;
+		this.errorHandler = config?.errorHandler;
+		this.logging = config?.logging;
+		this.tidProvider = config?.tidProvider;
+		this.timeout = config?.timeout;
+		this.apiKey = config?.apiKey;
+		this.headers = config?.headers;
 	}
 
 	public get apiKey(): string | undefined {

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -1,0 +1,64 @@
+import { Agent } from 'https';
+
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+import { AuthService } from '../services/internal/AuthService';
+import { ITidProvider } from '../types/auth/TidProvider';
+import { IErrorHandler } from '../types/ErrorHandler';
+import { IRettiwtConfig } from '../types/RettiwtConfig';
+
+export class RettiwtConfig implements IRettiwtConfig {
+	// Parameters for internal use
+	private _apiKey?: string;
+	private _httpsAgent: Agent;
+	private _userId: string | undefined;
+
+	// Parameters that can be set once, upon initialization
+	public readonly delay?: number | (() => number | Promise<number>);
+	public readonly errorHandler?: IErrorHandler;
+	public readonly logging?: boolean;
+	public readonly tidProvider?: ITidProvider;
+	public readonly timeout?: number;
+
+	// Parameters that can be changed on the fly
+	public headers?: { [key: string]: string };
+
+	/**
+	 * @param config - The config for Rettiwt of type {@link IRettiwtConfig}.
+	 */
+	public constructor(config: IRettiwtConfig) {
+		this._apiKey = config.apiKey;
+		this._httpsAgent = config.proxyUrl ? new HttpsProxyAgent(config.proxyUrl) : new Agent();
+		this._userId = config.apiKey ? AuthService.getUserId(config.apiKey) : undefined;
+		this.delay = config.delay;
+		this.errorHandler = config.errorHandler;
+		this.logging = config.logging;
+		this.tidProvider = config.tidProvider;
+		this.timeout = config.timeout;
+		this.apiKey = config.apiKey;
+		this.headers = config.headers;
+	}
+
+	public get apiKey(): string | undefined {
+		return this._apiKey;
+	}
+
+	/** The HTTPS agent instance to use. */
+	public get httpsAgent(): Agent {
+		return this._httpsAgent;
+	}
+
+	/** The ID of the user associated with the API key, if any. */
+	public get userId(): string | undefined {
+		return this._userId;
+	}
+
+	public set apiKey(apiKey: string | undefined) {
+		this._apiKey = apiKey;
+		this._userId = apiKey ? AuthService.getUserId(apiKey) : undefined;
+	}
+
+	public set proxyUrl(proxyUrl: URL | undefined) {
+		this._httpsAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : new Agent();
+	}
+}

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -175,7 +175,7 @@ export class FetcherService {
 	 * @param resource - The requested resource.
 	 * @param config - The request configuration.
 	 *
-	 * @typeParam T - The type of the returned response data.
+	 * @typeParam T - The type of the returned res1914679671410589981ponse data.
 	 *
 	 * @returns The raw data response received.
 	 *

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -1,8 +1,5 @@
-import { Agent } from 'https';
-
 import axios from 'axios';
 import { Cookie } from 'cookiejar';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import { allowGuestAuthentication, fetchResources, postResources } from '../../collections/Groups';
 import { requests } from '../../collections/Requests';
@@ -12,12 +9,12 @@ import { EResourceType } from '../../enums/Resource';
 import { FetchArgs } from '../../models/args/FetchArgs';
 import { PostArgs } from '../../models/args/PostArgs';
 import { AuthCredential } from '../../models/auth/AuthCredential';
+import { RettiwtConfig } from '../../models/RettiwtConfig';
 import { IFetchArgs } from '../../types/args/FetchArgs';
 import { IPostArgs } from '../../types/args/PostArgs';
 import { ITidHeader } from '../../types/auth/TidHeader';
 import { ITidProvider } from '../../types/auth/TidProvider';
 import { IErrorHandler } from '../../types/ErrorHandler';
-import { IRettiwtConfig } from '../../types/RettiwtConfig';
 
 import { AuthService } from '../internal/AuthService';
 import { ErrorService } from '../internal/ErrorService';
@@ -30,14 +27,8 @@ import { TidService } from '../internal/TidService';
  * @public
  */
 export class FetcherService {
-	/** The api key to use for authenticating against Twitter API as user. */
-	private readonly _apiKey?: string;
-
 	/** The AuthService instance to use. */
 	private readonly _auth: AuthService;
-
-	/** Custom headers to use for all requests */
-	private readonly _customHeaders?: { [key: string]: string };
 
 	/** The delay/delay function to use (ms). */
 	private readonly _delay?: number | (() => number | Promise<number>);
@@ -45,32 +36,26 @@ export class FetcherService {
 	/** The service used to handle HTTP and API errors */
 	private readonly _errorHandler: IErrorHandler;
 
-	/** The HTTPS agent to use. */
-	private readonly _httpsAgent: Agent;
-
 	/** Service responsible for generating the `x-client-transaction-id` header. */
 	private readonly _tidProvider: ITidProvider;
 
 	/** The max wait time for a response. */
 	private readonly _timeout: number;
 
-	/** The id of the authenticated user (if any). */
-	protected readonly userId?: string;
+	/** The config object. */
+	protected readonly config: RettiwtConfig;
 
 	/**
 	 * @param config - The config object for configuring the Rettiwt instance.
 	 */
-	public constructor(config?: IRettiwtConfig) {
-		LogService.enabled = config?.logging ?? false;
-		this._apiKey = config?.apiKey;
-		this.userId = config?.apiKey ? AuthService.getUserId(config.apiKey) : undefined;
-		this._httpsAgent = this.getHttpsAgent(config?.proxyUrl);
-		this._timeout = config?.timeout ?? 0;
-		this._errorHandler = config?.errorHandler ?? new ErrorService();
-		this._customHeaders = config?.headers;
-		this._delay = config?.delay;
-		this._auth = new AuthService(this._httpsAgent);
-		this._tidProvider = config?.tidProvider ?? new TidService(this._httpsAgent);
+	public constructor(config: RettiwtConfig) {
+		LogService.enabled = config.logging ?? false;
+		this.config = config;
+		this._delay = config.delay;
+		this._errorHandler = config.errorHandler ?? new ErrorService();
+		this._tidProvider = config.tidProvider ?? new TidService();
+		this._timeout = config.timeout ?? 0;
+		this._auth = new AuthService(config.httpsAgent);
 	}
 
 	/**
@@ -82,10 +67,10 @@ export class FetcherService {
 	 */
 	private checkAuthorization(resource: EResourceType): void {
 		// Logging
-		LogService.log(ELogActions.AUTHORIZATION, { authenticated: this.userId != undefined });
+		LogService.log(ELogActions.AUTHORIZATION, { authenticated: this.config.userId != undefined });
 
 		// Checking authorization status
-		if (!allowGuestAuthentication.includes(resource) && this.userId == undefined) {
+		if (!allowGuestAuthentication.includes(resource) && this.config.userId == undefined) {
 			throw new Error(EApiErrors.RESOURCE_NOT_ALLOWED);
 		}
 	}
@@ -96,12 +81,12 @@ export class FetcherService {
 	 * @returns The generated AuthCredential
 	 */
 	private async getCredential(): Promise<AuthCredential> {
-		if (this._apiKey) {
+		if (this.config.apiKey) {
 			// Logging
 			LogService.log(ELogActions.GET, { target: 'USER_CREDENTIAL' });
 
 			return new AuthCredential(
-				AuthService.decodeCookie(this._apiKey)
+				AuthService.decodeCookie(this.config.apiKey)
 					.split(';')
 					.map((item) => new Cookie(item)),
 			);
@@ -110,21 +95,6 @@ export class FetcherService {
 			LogService.log(ELogActions.GET, { target: 'NEW_GUEST_CREDENTIAL' });
 
 			return this._auth.guest();
-		}
-	}
-
-	/**
-	 * Gets the https agent based on whether a proxy is used or not.
-	 *
-	 * @param proxyUrl - Optional URL with proxy configuration to use for requests to Twitter API.
-	 *
-	 * @returns The https agent to use.
-	 */
-	private getHttpsAgent(proxyUrl?: URL): Agent {
-		if (proxyUrl) {
-			return new HttpsProxyAgent(proxyUrl);
-		} else {
-			return new Agent();
 		}
 	}
 
@@ -248,10 +218,10 @@ export class FetcherService {
 			...config.headers,
 			...cred.toHeader(),
 			...(await this.getTransactionHeader(config.method ?? '', config.url ?? '')),
-			...this._customHeaders,
+			...this.config.headers,
 		};
-		config.httpAgent = this._httpsAgent;
-		config.httpsAgent = this._httpsAgent;
+		config.httpAgent = this.config.httpsAgent;
+		config.httpsAgent = this.config.httpsAgent;
 		config.timeout = this._timeout;
 
 		// Sending the request

--- a/src/services/public/ListService.ts
+++ b/src/services/public/ListService.ts
@@ -3,9 +3,9 @@ import { EResourceType } from '../../enums/Resource';
 import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
+import { RettiwtConfig } from '../../models/RettiwtConfig';
 import { IListMembersResponse } from '../../types/raw/list/Members';
 import { IListTweetsResponse } from '../../types/raw/list/Tweets';
-import { IRettiwtConfig } from '../../types/RettiwtConfig';
 
 import { FetcherService } from './FetcherService';
 
@@ -15,7 +15,7 @@ export class ListService extends FetcherService {
 	 *
 	 * @internal
 	 */
-	public constructor(config?: IRettiwtConfig) {
+	public constructor(config: RettiwtConfig) {
 		super(config);
 	}
 

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -6,6 +6,7 @@ import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
 
+import { RettiwtConfig } from '../../models/RettiwtConfig';
 import { ITweetFilter } from '../../types/args/FetchArgs';
 import { INewTweet } from '../../types/args/PostArgs';
 import { IListTweetsResponse } from '../../types/raw/list/Tweets';
@@ -24,7 +25,6 @@ import { ITweetUnlikeResponse } from '../../types/raw/tweet/Unlike';
 import { ITweetUnpostResponse } from '../../types/raw/tweet/Unpost';
 import { ITweetUnretweetResponse } from '../../types/raw/tweet/Unretweet';
 import { ITweetUnscheduleResponse } from '../../types/raw/tweet/Unschedule';
-import { IRettiwtConfig } from '../../types/RettiwtConfig';
 
 import { FetcherService } from './FetcherService';
 
@@ -39,7 +39,7 @@ export class TweetService extends FetcherService {
 	 *
 	 * @internal
 	 */
-	public constructor(config?: IRettiwtConfig) {
+	public constructor(config: RettiwtConfig) {
 		super(config);
 	}
 
@@ -73,7 +73,7 @@ export class TweetService extends FetcherService {
 		let resource: EResourceType;
 
 		// If user is authenticated
-		if (this.userId != undefined) {
+		if (this.config.userId != undefined) {
 			resource = EResourceType.TWEET_DETAILS_ALT;
 
 			// Fetching raw tweet details

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -4,6 +4,7 @@ import { CursoredData } from '../../models/data/CursoredData';
 import { Notification } from '../../models/data/Notification';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
+import { RettiwtConfig } from '../../models/RettiwtConfig';
 import { IUserBookmarksResponse } from '../../types/raw/user/Bookmarks';
 import { IUserDetailsResponse } from '../../types/raw/user/Details';
 import { IUserFollowResponse } from '../../types/raw/user/Follow';
@@ -19,7 +20,6 @@ import { IUserSubscriptionsResponse } from '../../types/raw/user/Subscriptions';
 import { IUserTweetsResponse } from '../../types/raw/user/Tweets';
 import { IUserTweetsAndRepliesResponse } from '../../types/raw/user/TweetsAndReplies';
 import { IUserUnfollowResponse } from '../../types/raw/user/Unfollow';
-import { IRettiwtConfig } from '../../types/RettiwtConfig';
 
 import { FetcherService } from './FetcherService';
 
@@ -34,7 +34,7 @@ export class UserService extends FetcherService {
 	 *
 	 * @internal
 	 */
-	public constructor(config?: IRettiwtConfig) {
+	public constructor(config: RettiwtConfig) {
 		super(config);
 	}
 
@@ -378,7 +378,7 @@ export class UserService extends FetcherService {
 
 		// Fetching raw list of likes
 		const response = await this.request<IUserLikesResponse>(resource, {
-			id: this.userId,
+			id: this.config.userId,
 			count: count,
 			cursor: cursor,
 		});


### PR DESCRIPTION
The following options can be hot-swapped (changed during run-time):
- `apiKey`
- `headers`
- `proxyUrl`

The following example demonstrates hot-swapping:

#### 1. When using the `Rettiwt` wrapper:

```ts
import { Rettiwt } from 'rettiwt-api';

// Creating a simple Rettiwt instance with guest authentication
const rettiwt = new Rettiwt();

// Fetching details of a tweet with id '123'
rettiwt.tweet.details('123')
.then(res => {
    console.log(res);
})
.catch(err => {
    console.log(err);
});

// Changing the API key to '123456789'
rettiwt.apiKey = '123456789';

// Searching for tweets from user 'user1'
rettiwt.tweet.search({ fromUsers: ['user1'] })
.then(res => {
    console.log(res);
})
.catch(err => {
    console.log(err);
});
```

Similarly, `headers` and `proxyUrl` can be changed by setting the `rettiwt.headers` and `rettiwt.proxyUrl` fields respectively.

#### 2. When using `FetcherService` directly:

```ts
import { EResourceType, FetcherService, RettiwtConfig } from 'rettiwt-api';

// Creating a Rettiwt config
const config = new RettiwtConfig();

// Creating a simple Rettiwt instance with guest authentication
const fetcher = new FetcherService(config);

// Fetching details of a tweet with id '123'
fetcher.request(EResourceType.TWEET_DETAILS, { id: '123' })
.then(res => {
    console.log(res);
})
.catch(err => {
    console.log(err);
});

// Changing the API key to '123456789'
config.apiKey = '123456789';

// Searching for tweets from user 'user1'
fetcher.request( EResourceType.TWEET_SEARCH,  { filter: { fromUsers: ['user1'] } })
.then(res => {
    console.log(res);
})
.catch(err => {
    console.log(err);
});
```

Similarly, `headers` and `proxyUrl` can be changed by setting the `config.headers` and `config.proxyUrl` fields respectively.