### PR TITLE
Added getters to data models to get the raw data instead of parsed

### DIFF
--- a/src/models/data/List.ts
+++ b/src/models/data/List.ts
@@ -7,6 +7,9 @@ import { IList as IRawList } from '../../types/raw/base/List';
  * @public
  */
 export class List implements IList {
+	/** The raw list details. */
+	private readonly _raw: IRawList;
+
 	public createdAt: string;
 	public createdBy: string;
 	public description?: string;
@@ -19,6 +22,7 @@ export class List implements IList {
 	 * @param list - The raw list details.
 	 */
 	public constructor(list: IRawList) {
+		this._raw = { ...list };
 		this.id = list.id_str;
 		this.name = list.name;
 		this.createdAt = new Date(list.created_at).toISOString();
@@ -26,6 +30,11 @@ export class List implements IList {
 		this.memberCount = list.member_count;
 		this.subscriberCount = list.subscriber_count;
 		this.createdBy = list.user_results.result.id;
+	}
+
+	/** Get the raw list details. */
+	public get raw(): IRawList {
+		return { ...this._raw };
 	}
 
 	/**

--- a/src/models/data/Notification.ts
+++ b/src/models/data/Notification.ts
@@ -11,6 +11,9 @@ import { IUserNotificationsResponse } from '../../types/raw/user/Notifications';
  * @public
  */
 export class Notification implements INotification {
+	/** The raw notification details. */
+	private readonly _raw: IRawNotification;
+
 	public from: string[];
 	public id: string;
 	public message: string;
@@ -22,6 +25,8 @@ export class Notification implements INotification {
 	 * @param notification - The raw notification details.
 	 */
 	public constructor(notification: IRawNotification) {
+		this._raw = { ...notification };
+
 		// Getting the original notification type
 		const notificationType: string | undefined = findKeyByValue(ERawNotificationType, notification.icon.id);
 
@@ -37,6 +42,11 @@ export class Notification implements INotification {
 		this.type = notificationType
 			? ENotificationType[notificationType as keyof typeof ENotificationType]
 			: ENotificationType.UNDEFINED;
+	}
+
+	/** Get the raw notification details. */
+	public get raw(): IRawNotification {
+		return { ...this._raw };
 	}
 
 	/**

--- a/src/models/data/Tweet.ts
+++ b/src/models/data/Tweet.ts
@@ -19,6 +19,9 @@ import { User } from './User';
  * @public
  */
 export class Tweet implements ITweet {
+	/** The raw tweet details. */
+	private readonly _raw: IRawTweet;
+
 	public bookmarkCount: number;
 	public conversationId: string;
 	public createdAt: string;
@@ -42,6 +45,7 @@ export class Tweet implements ITweet {
 	 * @param tweet - The raw tweet details.
 	 */
 	public constructor(tweet: IRawTweet) {
+		this._raw = { ...tweet };
 		this.id = tweet.rest_id;
 		this.conversationId = tweet.legacy.conversation_id_str;
 		this.createdAt = new Date(tweet.legacy.created_at).toISOString();
@@ -60,6 +64,11 @@ export class Tweet implements ITweet {
 		this.bookmarkCount = tweet.legacy.bookmark_count;
 		this.retweetedTweet = this.getRetweetedTweet(tweet);
 		this.url = `https://x.com/${this.tweetBy.userName}/status/${this.id}`;
+	}
+
+	/** Get the raw tweet details. */
+	public get raw(): IRawTweet {
+		return { ...this._raw };
 	}
 
 	/**

--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -11,6 +11,9 @@ import { ITimelineUser as IRawTimelineUser } from '../../types/raw/composite/Tim
  * @public
  */
 export class User implements IUser {
+	/** The raw user details. */
+	private readonly _raw: IRawUser;
+
 	public createdAt: string;
 	public description?: string;
 	public followersCount: number;
@@ -30,6 +33,7 @@ export class User implements IUser {
 	 * @param user - The raw user details.
 	 */
 	public constructor(user: IRawUser) {
+		this._raw = { ...user };
 		this.id = user.rest_id;
 		this.userName = user.legacy.screen_name;
 		this.fullName = user.legacy.name;
@@ -44,6 +48,11 @@ export class User implements IUser {
 		this.pinnedTweet = user.legacy.pinned_tweet_ids_str[0];
 		this.profileBanner = user.legacy.profile_banner_url;
 		this.profileImage = user.legacy.profile_image_url_https;
+	}
+
+	/** Get the raw user details. */
+	public get raw(): IRawUser {
+		return { ...this._raw };
 	}
 
 	/**


### PR DESCRIPTION
The getter `raw` has been added to the following data models:
- `List`
- `Notitification`
- `Tweet`
- `User`

For example, to get the raw user details as returned by Twitter, instead of the parsed one:

```ts
import { Rettiwt } from 'rettiwt-api';

// Creating a new Rettiwt instance
const rettiwt = new Rettiwt();

// Getting the raw details of the user with username 'user1'
rettiwt.user.details('user1')
.then(res => {
    console.log(res.raw);
})
.catch(err => {
    console.log(err);
});
```