### PR TITLE
Added ability to get replies to a tweet sorted in a specific order

### DIFF
--- a/src/collections/Requests.ts
+++ b/src/collections/Requests.ts
@@ -8,6 +8,8 @@ import { UserRequests } from '../requests/User';
 import { IFetchArgs } from '../types/args/FetchArgs';
 import { IPostArgs } from '../types/args/PostArgs';
 
+import { rawTweetRepliesSortType } from './Tweet';
+
 /**
  * The collection of requests to various resources.
  *
@@ -29,7 +31,8 @@ export const requests: { [key in keyof typeof EResourceType]: (args: IFetchArgs 
 	TWEET_LIKE: (args: IPostArgs) => TweetRequests.like(args.id!),
 	TWEET_LIKERS: (args: IFetchArgs) => TweetRequests.likers(args.id!, args.count, args.cursor),
 	TWEET_POST: (args: IPostArgs) => TweetRequests.post(args.tweet!),
-	TWEET_REPLIES: (args: IFetchArgs) => TweetRequests.replies(args.id!, args.cursor),
+	TWEET_REPLIES: (args: IFetchArgs) =>
+		TweetRequests.replies(args.id!, args.cursor, args.sortBy ? rawTweetRepliesSortType[args.sortBy] : undefined),
 	TWEET_RETWEET: (args: IPostArgs) => TweetRequests.retweet(args.id!),
 	TWEET_RETWEETERS: (args: IFetchArgs) => TweetRequests.retweeters(args.id!, args.count, args.cursor),
 	TWEET_SCHEDULE: (args: IPostArgs) => TweetRequests.schedule(args.tweet!),

--- a/src/collections/Tweet.ts
+++ b/src/collections/Tweet.ts
@@ -1,0 +1,17 @@
+import { ERawTweetRepliesSortType } from '../enums/raw/Tweet';
+import { ETweetRepliesSortType } from '../enums/Tweet';
+
+/**
+ * The collection of mapping from parsed reply sort type to raw reply sort type.
+ *
+ * @internal
+ */
+export const rawTweetRepliesSortType: { [key in keyof typeof ETweetRepliesSortType]: ERawTweetRepliesSortType } = {
+	/* eslint-disable @typescript-eslint/naming-convention */
+
+	LATEST: ERawTweetRepliesSortType.LATEST,
+	LIKES: ERawTweetRepliesSortType.LIKES,
+	RELEVANCE: ERawTweetRepliesSortType.RELEVACE,
+
+	/* eslint-enable @typescript-eslint/naming-convention */
+};

--- a/src/enums/Tweet.ts
+++ b/src/enums/Tweet.ts
@@ -1,0 +1,8 @@
+/**
+ * The different types of sorting options when fetching replies to tweets.
+ */
+export enum ETweetRepliesSortType {
+	LIKES = 'LIKES',
+	LATEST = 'LATEST',
+	RELEVANCE = 'RELEVANCE',
+}

--- a/src/enums/raw/Tweet.ts
+++ b/src/enums/raw/Tweet.ts
@@ -1,9 +1,18 @@
 /**
- * The different types of search results when searching for Tweets.
+ * The different types of search results when searching for tweets.
  *
  * @public
  */
 export enum ERawTweetSearchResultType {
 	LATEST = 'Latest',
 	TOP = 'Top',
+}
+
+/**
+ * The different types of sorting options when fetching replies to tweets.
+ */
+export enum ERawTweetRepliesSortType {
+	RELEVACE = 'Relevance',
+	LATEST = 'Recency',
+	LIKES = 'Likes',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export * from './enums/Logging';
 export * from './enums/Media';
 export * from './enums/Notification';
 export * from './enums/Resource';
+export * from './enums/Tweet';
 
 // MODELS
 export * from './models/args/FetchArgs';

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -1,4 +1,5 @@
 import { EResourceType } from '../../enums/Resource';
+import { ETweetRepliesSortType } from '../../enums/Tweet';
 import { IFetchArgs, ITweetFilter } from '../../types/args/FetchArgs';
 
 /**
@@ -12,6 +13,7 @@ export class FetchArgs implements IFetchArgs {
 	public filter?: TweetFilter;
 	public id?: string;
 	public ids?: string[];
+	public sortBy?: ETweetRepliesSortType;
 
 	/**
 	 * @param resource - The resource to be fetched.
@@ -23,6 +25,7 @@ export class FetchArgs implements IFetchArgs {
 		this.count = args.count;
 		this.cursor = args.cursor;
 		this.filter = args.filter ? new TweetFilter(args.filter) : undefined;
+		this.sortBy = args.sortBy;
 	}
 }
 

--- a/src/requests/Tweet.ts
+++ b/src/requests/Tweet.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 
-import { ERawTweetSearchResultType } from '../enums/raw/Tweet';
+import { ERawTweetRepliesSortType, ERawTweetSearchResultType } from '../enums/raw/Tweet';
 import { TweetFilter } from '../models/args/FetchArgs';
 import { NewTweet } from '../models/args/PostArgs';
 import { MediaVariable, ReplyVariable } from '../models/params/Variables';
@@ -266,7 +266,7 @@ export class TweetRequests {
 	 * @param id - The id of the tweet whose replies are to be fetched.
 	 * @param cursor - The cursor to the batch of replies to fetch.
 	 */
-	public static replies(id: string, cursor?: string): AxiosRequestConfig {
+	public static replies(id: string, cursor?: string, sortBy?: ERawTweetRepliesSortType): AxiosRequestConfig {
 		return {
 			method: 'get',
 			url: 'https://x.com/i/api/graphql/_8aYOgEDz35BrBcBal1-_w/TweetDetail',
@@ -275,6 +275,7 @@ export class TweetRequests {
 				variables: JSON.stringify({
 					focalTweetId: id,
 					cursor: cursor,
+					rankingMode: sortBy ?? ERawTweetRepliesSortType.RELEVACE,
 					referrer: 'tweet',
 					controller_data: cursor,
 					with_rux_injections: false,

--- a/src/requests/Tweet.ts
+++ b/src/requests/Tweet.ts
@@ -275,16 +275,14 @@ export class TweetRequests {
 				variables: JSON.stringify({
 					focalTweetId: id,
 					cursor: cursor,
-					rankingMode: sortBy ?? ERawTweetRepliesSortType.RELEVACE,
 					referrer: 'tweet',
-					controller_data: cursor,
 					with_rux_injections: false,
-					includePromotedContent: false,
+					rankingMode: sortBy ?? ERawTweetRepliesSortType.RELEVACE,
+					includePromotedContent: true,
 					withCommunity: true,
 					withQuickPromoteEligibilityTweetFields: true,
 					withBirdwatchNotes: true,
 					withVoice: true,
-					withV2Timeline: true,
 				}),
 				features: JSON.stringify({
 					rweb_video_screen_enabled: false,

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -2,6 +2,7 @@ import { statSync } from 'fs';
 
 import { extractors } from '../../collections/Extractors';
 import { EResourceType } from '../../enums/Resource';
+import { ETweetRepliesSortType } from '../../enums/Tweet';
 import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
@@ -334,6 +335,7 @@ export class TweetService extends FetcherService {
 	 *
 	 * @param id - The id of the target tweet.
 	 * @param cursor - The cursor to the batch of replies to fetch.
+	 * @param sortBy - The sorting order of the replies to fetch. Default is {@link ETweetRepliesSortType.RECENT}.
 	 *
 	 * @returns The list of replies to the given tweet.
 	 *
@@ -354,13 +356,18 @@ export class TweetService extends FetcherService {
 	 * });
 	 * ```
 	 */
-	public async replies(id: string, cursor?: string): Promise<CursoredData<Tweet>> {
+	public async replies(
+		id: string,
+		cursor?: string,
+		sortBy: ETweetRepliesSortType = ETweetRepliesSortType.LATEST,
+	): Promise<CursoredData<Tweet>> {
 		const resource = EResourceType.TWEET_REPLIES;
 
 		// Fetching raw list of replies
 		const response = await this.request<ITweetDetailsResponse>(resource, {
 			id: id,
 			cursor: cursor,
+			sortBy: sortBy,
 		});
 
 		// Deserializing response

--- a/src/types/args/FetchArgs.ts
+++ b/src/types/args/FetchArgs.ts
@@ -1,3 +1,5 @@
+import { ETweetRepliesSortType } from '../../enums/Tweet';
+
 /**
  * Options specifying the data that is to be fetched.
  *
@@ -55,6 +57,14 @@ export interface IFetchArgs {
 	 * - Required only for {@link EResourceType.TWEET_DETAILS_BULK} and {@link EResourceType.USER_DETAILS_BY_IDS_BULK}.
 	 */
 	ids?: string[];
+
+	/**
+	 * The sorting to use for tweet results.
+	 *
+	 * @remarks
+	 * - Only works for {@link EResourceType.TWEET_REPLIES}.
+	 */
+	sortBy?: ETweetRepliesSortType;
 }
 
 /**


### PR DESCRIPTION
This can be achieved by using a third parameter of type `ETweetRepliesSortType`, which can be one of the three values:
- `LIKES` - Replies are sorted by likes, highest to lowest
- `LATEST` - Replies are sorted by time, from most recent to oldest (default behaviour for Rettiwt)
- `RELEVANCE` - Replies are sorted by relevance (default behaviour of Twitter Web App)