### PR TITLE
Updated search filters for even fine-grained searches

### DIFF
--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -180,8 +180,10 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 		.option('-l, --min-likes <number>', 'Matches the tweets that have a minimum of given number of likes')
 		.option('-x, --min-retweets <number>', 'Matches the tweets that have a minimum of given number of retweets')
 		.option('-q, --quoted <string>', 'Matches the tweets that quote the tweet with the given id')
-		.option('--exclude-links', 'Matches tweets that do not contain links')
-		.option('--exclude-replies', 'Matches the tweets that are not replies')
+		.option('--only-original', 'Matches tweets are original posts')
+		.option('--only-replies', 'Matches tweets that are replies')
+		.option('--only-text', 'Matches tweets that are only text')
+		.option('--only-links', 'Matches tweets that only contain links like media, quotes, etc')
 		.option('-s, --start <string>', 'Matches the tweets made since the given date (valid date/time string)')
 		.option('-e, --end <string>', 'Matches the tweets made upto the given date (valid date/time string)')
 		.option('--top', 'Matches top tweets instead of latest')
@@ -292,8 +294,6 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
  */
 class TweetSearchOptions {
 	public end?: string;
-	public excludeLinks?: boolean = false;
-	public excludeReplies?: boolean = false;
 	public excludeWords?: string;
 	public from?: string;
 	public hashtags?: string;
@@ -303,6 +303,10 @@ class TweetSearchOptions {
 	public minLikes?: number;
 	public minReplies?: number;
 	public minRetweets?: number;
+	public onlyLinks?: boolean = false;
+	public onlyOriginal?: boolean = false;
+	public onlyReplies?: boolean = false;
+	public onlyText?: boolean = false;
 	public optionalWords?: string;
 	public phrase?: string;
 	public quoted?: string;
@@ -330,9 +334,11 @@ class TweetSearchOptions {
 		this.minReplies = options?.minReplies;
 		this.minLikes = options?.minLikes;
 		this.minRetweets = options?.minRetweets;
+		this.onlyLinks = options?.onlyLinks;
+		this.onlyOriginal = options?.onlyOriginal;
+		this.onlyReplies = options?.onlyReplies;
+		this.onlyText = options?.onlyText;
 		this.quoted = options?.quoted;
-		this.excludeLinks = options?.excludeLinks;
-		this.excludeReplies = options?.excludeReplies;
 		this.start = options?.start;
 		this.end = options?.end;
 		this.stream = options?.stream;
@@ -359,9 +365,11 @@ class TweetSearchOptions {
 			minReplies: this.minReplies,
 			minLikes: this.minLikes,
 			minRetweets: this.minRetweets,
+			onlyLinks: this.onlyLinks,
+			onlyOriginal: this.onlyOriginal,
+			onlyReplies: this.onlyReplies,
+			onlyText: this.onlyText,
 			quoted: this.quoted,
-			links: !this.excludeLinks,
-			replies: !this.excludeReplies,
 			startDate: this.start ? new Date(this.start) : undefined,
 			top: this.top,
 			endDate: this.end ? new Date(this.end) : undefined,

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -40,16 +40,18 @@ export class TweetFilter implements ITweetFilter {
 	public includePhrase?: string;
 	public includeWords?: string[];
 	public language?: string;
-	public links?: boolean;
 	public list?: string;
 	public maxId?: string;
 	public mentions?: string[];
 	public minLikes?: number;
 	public minReplies?: number;
 	public minRetweets?: number;
+	public onlyLinks?: boolean;
+	public onlyOriginal?: boolean;
+	public onlyReplies?: boolean;
+	public onlyText?: boolean;
 	public optionalWords?: string[];
 	public quoted?: string;
-	public replies?: boolean;
 	public sinceId?: string;
 	public startDate?: Date;
 	public toUsers?: string[];
@@ -65,9 +67,7 @@ export class TweetFilter implements ITweetFilter {
 		this.hashtags = filter.hashtags;
 		this.includePhrase = filter.includePhrase;
 		this.language = filter.language;
-		this.links = filter.links;
 		this.list = filter.list;
-		this.replies = filter.replies;
 		this.mentions = filter.mentions;
 		this.quoted = filter.quoted;
 		this.sinceId = filter.sinceId;
@@ -75,6 +75,10 @@ export class TweetFilter implements ITweetFilter {
 		this.minLikes = filter.minLikes;
 		this.minReplies = filter.minReplies;
 		this.minRetweets = filter.minRetweets;
+		this.onlyLinks = filter.onlyLinks;
+		this.onlyOriginal = filter.onlyOriginal;
+		this.onlyReplies = filter.onlyReplies;
+		this.onlyText = filter.onlyText;
 		this.optionalWords = filter.optionalWords;
 		this.startDate = filter.startDate;
 		this.toUsers = filter.toUsers;
@@ -139,8 +143,10 @@ export class TweetFilter implements ITweetFilter {
 			]
 				.filter((item) => item !== '()' && item !== '')
 				.join(' ') +
-			(this.links == false ? ' -filter:links' : '') +
-			(this.replies == false ? ' -filter:replies' : '')
+			(this.onlyText === true ? ' -filter:links' : '') +
+			(this.onlyOriginal === true ? ' -filter:replies' : '') +
+			(this.onlyLinks === true ? ' filter:links' : '') +
+			(this.onlyReplies === true ? ' filter:replies' : '')
 		);
 	}
 }

--- a/src/types/args/FetchArgs.ts
+++ b/src/types/args/FetchArgs.ts
@@ -104,9 +104,6 @@ export interface ITweetFilter {
 	/** The language of the tweets to search. */
 	language?: string;
 
-	/** Whether to fetch tweets that are links or not. */
-	links?: boolean;
-
 	/** The list from which tweets are to be searched. */
 	list?: string;
 
@@ -130,14 +127,27 @@ export interface ITweetFilter {
 	/** The minimum number of retweets to search by. */
 	minRetweets?: number;
 
+	/**
+	 * Whether to search only posts that contain links.
+	 *
+	 * @remarks 'links' includes things like media, quotes, retweets, etc.
+	 */
+	onlyLinks?: boolean;
+
+	/** Whether to search only original posts. */
+	onlyOriginal?: boolean;
+
+	/** Whether to search only replies */
+	onlyReplies?: boolean;
+
+	/** Whether to search posts that only contain text. */
+	onlyText?: boolean;
+
 	/** The optional words to search. */
 	optionalWords?: string[];
 
 	/** The id of the tweet which is quoted in the tweets to search. */
 	quoted?: string;
-
-	/** Whether to fetch tweets that are replies or not. */
-	replies?: boolean;
 
 	/** The id of the tweet, after which the tweets are to be searched. */
 	sinceId?: string;


### PR DESCRIPTION
This removes the following filters:
- `replies`
- `links`

And replaces them with the following four new filters:
- `onlyOriginal` - Searches tweets that are only original tweets
- `onlyText` - Searches tweets that only contain text
- `onlyReplies` - Searches tweets that are only replies
- `onlyLinks` - Searches tweets that only contain links (URLs, media, quotes, etc)

If all four are not set or set to `false`, all results are included.