### PR TITLE
Changed enum naming convention

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,37 +22,42 @@ module.exports = {
 		'@typescript-eslint/naming-convention': [
 			'warn',
 			{
-				selector: ['class'],
+				selector: ['class', 'enum'],
 				format: ['PascalCase'],
 			},
 			{
-				selector: 'interface',
+				selector: ['interface'],
 				format: ['PascalCase'],
 				prefix: ['I'],
 			},
 			{
-				selector: 'enum',
+				selector: ['typeAlias'],
 				format: ['PascalCase'],
-				prefix: ['E'],
 			},
 			{
-				selector: ['variableLike', 'memberLike'],
+				selector: ['memberLike', 'variableLike'],
 				format: ['camelCase'],
+				leadingUnderscore: 'allow',
 			},
 			{
-				selector: ['variableLike', 'property'],
+				selector: ['memberLike'],
 				modifiers: ['private'],
 				format: ['camelCase'],
 				leadingUnderscore: 'require',
 			},
 			{
-				selector: ['variableLike', 'memberLike'],
+				selector: ['memberLike'],
 				modifiers: ['static', 'readonly'],
 				format: ['UPPER_CASE'],
 			},
 			{
-				selector: 'enumMember',
+				selector: ['enumMember'],
 				format: ['UPPER_CASE'],
+			},
+			{
+				selector: ['variable'],
+				modifiers: ['global'],
+				format: ['PascalCase'],
 			},
 		],
 		'@typescript-eslint/explicit-function-return-type': 'error',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,33 +8,32 @@ import user from './commands/User';
 import { Rettiwt } from './Rettiwt';
 
 // Creating a new commandline program
-const program = createCommand('rettiwt')
+const Program = createCommand('rettiwt')
 	.description('A CLI tool for accessing the Twitter API for free!')
 	.passThroughOptions()
 	.enablePositionalOptions();
 
 // Adding options
-program
-	.option('-k, --key <string>', 'The API key to use for authentication')
+Program.option('-k, --key <string>', 'The API key to use for authentication')
 	.option('-l, --log', 'Enable logging to console')
 	.option('-p, --proxy <string>', 'The URL to the proxy to use')
 	.option('-t, --timeout <number>', 'The timout (in milli-seconds) to use for requests');
 
 // Parsing the program to get supplied options
-program.parse();
+Program.parse();
 
 // Initializing Rettiwt instance using the given options
-const rettiwt: Rettiwt = new Rettiwt({
-	apiKey: process.env.API_KEY ?? (program.opts().key as string),
-	logging: program.opts().log ? true : false,
-	proxyUrl: program.opts().proxy as URL,
-	timeout: program.opts().timeout ? Number(program.opts().timeout) : undefined,
+const RettiwtInstance = new Rettiwt({
+	apiKey: process.env.API_KEY ?? (Program.opts().key as string),
+	logging: Program.opts().log ? true : false,
+	proxyUrl: Program.opts().proxy as URL,
+	timeout: Program.opts().timeout ? Number(Program.opts().timeout) : undefined,
 });
 
 // Adding sub-commands
-program.addCommand(list(rettiwt));
-program.addCommand(tweet(rettiwt));
-program.addCommand(user(rettiwt));
+Program.addCommand(list(RettiwtInstance));
+Program.addCommand(tweet(RettiwtInstance));
+Program.addCommand(user(RettiwtInstance));
 
 // Finalizing the CLI
-program.parse();
+Program.parse();

--- a/src/collections/Extractors.ts
+++ b/src/collections/Extractors.ts
@@ -1,4 +1,4 @@
-import { EBaseType } from '../enums/Data';
+import { BaseType } from '../enums/Data';
 import { CursoredData } from '../models/data/CursoredData';
 import { Notification } from '../models/data/Notification';
 import { Tweet } from '../models/data/Tweet';
@@ -43,13 +43,13 @@ import { IUserUnfollowResponse } from '../types/raw/user/Unfollow';
  *
  * @internal
  */
-export const extractors = {
+export const Extractors = {
 	/* eslint-disable @typescript-eslint/naming-convention */
 
 	LIST_MEMBERS: (response: IListMembersResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	LIST_TWEETS: (response: IListTweetsResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 
 	MEDIA_UPLOAD_APPEND: (): void => undefined,
 	MEDIA_UPLOAD_FINALIZE: (): void => undefined,
@@ -61,17 +61,17 @@ export const extractors = {
 	TWEET_DETAILS_BULK: (response: ITweetDetailsBulkResponse, ids: string[]): Tweet[] => Tweet.multiple(response, ids),
 	TWEET_LIKE: (response: ITweetLikeResponse): boolean => (response?.data?.favorite_tweet ? true : false),
 	TWEET_LIKERS: (response: ITweetLikersResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	TWEET_POST: (response: ITweetPostResponse): string =>
 		response?.data?.create_tweet?.tweet_results?.result?.rest_id ?? undefined,
 	TWEET_REPLIES: (response: ITweetDetailsResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	TWEET_RETWEET: (response: ITweetRetweetResponse): boolean => (response?.data?.create_retweet ? true : false),
 	TWEET_RETWEETERS: (response: ITweetRetweetersResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	TWEET_SCHEDULE: (response: ITweetScheduleResponse): string => response?.data?.tweet?.rest_id ?? undefined,
 	TWEET_SEARCH: (response: ITweetSearchResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	TWEET_UNLIKE: (response: ITweetUnlikeResponse): boolean => (response?.data?.unfavorite_tweet ? true : false),
 	TWEET_UNPOST: (response: ITweetUnpostResponse): boolean => (response?.data?.delete_tweet ? true : false),
 	TWEET_UNRETWEET: (response: ITweetUnretweetResponse): boolean =>
@@ -79,36 +79,36 @@ export const extractors = {
 	TWEET_UNSCHEDULE: (response: ITweetUnscheduleResponse): boolean => response?.data?.scheduledtweet_delete == 'Done',
 
 	USER_AFFILIATES: (response: IUserAffiliatesResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	USER_BOOKMARKS: (response: IUserBookmarksResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_DETAILS_BY_USERNAME: (response: IUserDetailsResponse): User | undefined => User.single(response),
 	USER_DETAILS_BY_ID: (response: IUserDetailsResponse): User | undefined => User.single(response),
 	USER_DETAILS_BY_IDS_BULK: (response: IUserDetailsBulkResponse, ids: string[]): User[] =>
 		User.multiple(response, ids),
 	USER_FEED_FOLLOWED: (response: IUserFollowedResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_FEED_RECOMMENDED: (response: IUserRecommendedResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_FOLLOW: (response: IUserFollowResponse): boolean => (response?.id ? true : false),
 	USER_FOLLOWING: (response: IUserFollowingResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	USER_FOLLOWERS: (response: IUserFollowersResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	USER_HIGHLIGHTS: (response: IUserHighlightsResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_LIKES: (response: IUserLikesResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_MEDIA: (response: IUserMediaResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_NOTIFICATIONS: (response: IUserNotificationsResponse): CursoredData<Notification> =>
-		new CursoredData<Notification>(response, EBaseType.NOTIFICATION),
+		new CursoredData<Notification>(response, BaseType.NOTIFICATION),
 	USER_SUBSCRIPTIONS: (response: IUserSubscriptionsResponse): CursoredData<User> =>
-		new CursoredData<User>(response, EBaseType.USER),
+		new CursoredData<User>(response, BaseType.USER),
 	USER_TIMELINE: (response: IUserTweetsResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_TIMELINE_AND_REPLIES: (response: IUserTweetsAndRepliesResponse): CursoredData<Tweet> =>
-		new CursoredData<Tweet>(response, EBaseType.TWEET),
+		new CursoredData<Tweet>(response, BaseType.TWEET),
 	USER_UNFOLLOW: (response: IUserUnfollowResponse): boolean => (response?.id ? true : false),
 
 	/* eslint-enable @typescript-eslint/naming-convention */

--- a/src/collections/Groups.ts
+++ b/src/collections/Groups.ts
@@ -1,14 +1,14 @@
-import { EResourceType } from '../enums/Resource';
+import { ResourceType } from '../enums/Resource';
 
 /**
  * Collection of resources that allow guest authentication.
  *
  * @internal
  */
-export const allowGuestAuthentication = [
-	EResourceType.TWEET_DETAILS,
-	EResourceType.USER_DETAILS_BY_USERNAME,
-	EResourceType.USER_TIMELINE,
+export const AllowGuestAuthenticationGroup = [
+	ResourceType.TWEET_DETAILS,
+	ResourceType.USER_DETAILS_BY_USERNAME,
+	ResourceType.USER_TIMELINE,
 ];
 
 /**
@@ -16,32 +16,32 @@ export const allowGuestAuthentication = [
  *
  * @internal
  */
-export const fetchResources = [
-	EResourceType.LIST_MEMBERS,
-	EResourceType.LIST_TWEETS,
-	EResourceType.TWEET_DETAILS,
-	EResourceType.TWEET_DETAILS_ALT,
-	EResourceType.TWEET_DETAILS_BULK,
-	EResourceType.TWEET_LIKERS,
-	EResourceType.TWEET_REPLIES,
-	EResourceType.TWEET_RETWEETERS,
-	EResourceType.TWEET_SEARCH,
-	EResourceType.USER_AFFILIATES,
-	EResourceType.USER_BOOKMARKS,
-	EResourceType.USER_DETAILS_BY_USERNAME,
-	EResourceType.USER_DETAILS_BY_ID,
-	EResourceType.USER_DETAILS_BY_IDS_BULK,
-	EResourceType.USER_FEED_FOLLOWED,
-	EResourceType.USER_FEED_RECOMMENDED,
-	EResourceType.USER_FOLLOWING,
-	EResourceType.USER_FOLLOWERS,
-	EResourceType.USER_HIGHLIGHTS,
-	EResourceType.USER_LIKES,
-	EResourceType.USER_MEDIA,
-	EResourceType.USER_NOTIFICATIONS,
-	EResourceType.USER_SUBSCRIPTIONS,
-	EResourceType.USER_TIMELINE,
-	EResourceType.USER_TIMELINE_AND_REPLIES,
+export const FetchResourcesGroup = [
+	ResourceType.LIST_MEMBERS,
+	ResourceType.LIST_TWEETS,
+	ResourceType.TWEET_DETAILS,
+	ResourceType.TWEET_DETAILS_ALT,
+	ResourceType.TWEET_DETAILS_BULK,
+	ResourceType.TWEET_LIKERS,
+	ResourceType.TWEET_REPLIES,
+	ResourceType.TWEET_RETWEETERS,
+	ResourceType.TWEET_SEARCH,
+	ResourceType.USER_AFFILIATES,
+	ResourceType.USER_BOOKMARKS,
+	ResourceType.USER_DETAILS_BY_USERNAME,
+	ResourceType.USER_DETAILS_BY_ID,
+	ResourceType.USER_DETAILS_BY_IDS_BULK,
+	ResourceType.USER_FEED_FOLLOWED,
+	ResourceType.USER_FEED_RECOMMENDED,
+	ResourceType.USER_FOLLOWING,
+	ResourceType.USER_FOLLOWERS,
+	ResourceType.USER_HIGHLIGHTS,
+	ResourceType.USER_LIKES,
+	ResourceType.USER_MEDIA,
+	ResourceType.USER_NOTIFICATIONS,
+	ResourceType.USER_SUBSCRIPTIONS,
+	ResourceType.USER_TIMELINE,
+	ResourceType.USER_TIMELINE_AND_REPLIES,
 ];
 
 /**
@@ -49,18 +49,18 @@ export const fetchResources = [
  *
  * @internal
  */
-export const postResources = [
-	EResourceType.MEDIA_UPLOAD_APPEND,
-	EResourceType.MEDIA_UPLOAD_FINALIZE,
-	EResourceType.MEDIA_UPLOAD_INITIALIZE,
-	EResourceType.TWEET_LIKE,
-	EResourceType.TWEET_POST,
-	EResourceType.TWEET_RETWEET,
-	EResourceType.TWEET_SCHEDULE,
-	EResourceType.TWEET_UNLIKE,
-	EResourceType.TWEET_UNPOST,
-	EResourceType.TWEET_UNRETWEET,
-	EResourceType.TWEET_UNSCHEDULE,
-	EResourceType.USER_FOLLOW,
-	EResourceType.USER_UNFOLLOW,
+export const PostResourcesGroup = [
+	ResourceType.MEDIA_UPLOAD_APPEND,
+	ResourceType.MEDIA_UPLOAD_FINALIZE,
+	ResourceType.MEDIA_UPLOAD_INITIALIZE,
+	ResourceType.TWEET_LIKE,
+	ResourceType.TWEET_POST,
+	ResourceType.TWEET_RETWEET,
+	ResourceType.TWEET_SCHEDULE,
+	ResourceType.TWEET_UNLIKE,
+	ResourceType.TWEET_UNPOST,
+	ResourceType.TWEET_UNRETWEET,
+	ResourceType.TWEET_UNSCHEDULE,
+	ResourceType.USER_FOLLOW,
+	ResourceType.USER_UNFOLLOW,
 ];

--- a/src/collections/Requests.ts
+++ b/src/collections/Requests.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 
-import { EResourceType } from '../enums/Resource';
+import { ResourceType } from '../enums/Resource';
 import { ListRequests } from '../requests/List';
 import { MediaRequests } from '../requests/Media';
 import { TweetRequests } from '../requests/Tweet';
@@ -8,14 +8,14 @@ import { UserRequests } from '../requests/User';
 import { IFetchArgs } from '../types/args/FetchArgs';
 import { IPostArgs } from '../types/args/PostArgs';
 
-import { rawTweetRepliesSortType } from './Tweet';
+import { TweetRepliesSortTypeMap } from './Tweet';
 
 /**
  * Collection of requests to various resources.
  *
  * @internal
  */
-export const requests: { [key in keyof typeof EResourceType]: (args: IFetchArgs | IPostArgs) => AxiosRequestConfig } = {
+export const Requests: { [key in keyof typeof ResourceType]: (args: IFetchArgs | IPostArgs) => AxiosRequestConfig } = {
 	/* eslint-disable @typescript-eslint/naming-convention */
 
 	LIST_MEMBERS: (args: IFetchArgs) => ListRequests.members(args.id!, args.count, args.cursor),
@@ -32,7 +32,7 @@ export const requests: { [key in keyof typeof EResourceType]: (args: IFetchArgs 
 	TWEET_LIKERS: (args: IFetchArgs) => TweetRequests.likers(args.id!, args.count, args.cursor),
 	TWEET_POST: (args: IPostArgs) => TweetRequests.post(args.tweet!),
 	TWEET_REPLIES: (args: IFetchArgs) =>
-		TweetRequests.replies(args.id!, args.cursor, args.sortBy ? rawTweetRepliesSortType[args.sortBy] : undefined),
+		TweetRequests.replies(args.id!, args.cursor, args.sortBy ? TweetRepliesSortTypeMap[args.sortBy] : undefined),
 	TWEET_RETWEET: (args: IPostArgs) => TweetRequests.retweet(args.id!),
 	TWEET_RETWEETERS: (args: IFetchArgs) => TweetRequests.retweeters(args.id!, args.count, args.cursor),
 	TWEET_SCHEDULE: (args: IPostArgs) => TweetRequests.schedule(args.tweet!),

--- a/src/collections/Tweet.ts
+++ b/src/collections/Tweet.ts
@@ -1,17 +1,17 @@
-import { ERawTweetRepliesSortType } from '../enums/raw/Tweet';
-import { ETweetRepliesSortType } from '../enums/Tweet';
+import { RawTweetRepliesSortType } from '../enums/raw/Tweet';
+import { TweetRepliesSortType } from '../enums/Tweet';
 
 /**
  * Collection of mapping from parsed reply sort type to raw reply sort type.
  *
  * @internal
  */
-export const rawTweetRepliesSortType: { [key in keyof typeof ETweetRepliesSortType]: ERawTweetRepliesSortType } = {
+export const TweetRepliesSortTypeMap: { [key in keyof typeof TweetRepliesSortType]: RawTweetRepliesSortType } = {
 	/* eslint-disable @typescript-eslint/naming-convention */
 
-	LATEST: ERawTweetRepliesSortType.LATEST,
-	LIKES: ERawTweetRepliesSortType.LIKES,
-	RELEVANCE: ERawTweetRepliesSortType.RELEVACE,
+	LATEST: RawTweetRepliesSortType.LATEST,
+	LIKES: RawTweetRepliesSortType.LIKES,
+	RELEVANCE: RawTweetRepliesSortType.RELEVACE,
 
 	/* eslint-enable @typescript-eslint/naming-convention */
 };

--- a/src/enums/Api.ts
+++ b/src/enums/Api.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum EApiErrors {
+export enum ApiErrors {
 	COULD_NOT_AUTHENTICATE = 'Failed to authenticate',
 	BAD_AUTHENTICATION = 'Invalid authentication data',
 	RESOURCE_NOT_ALLOWED = 'Not authorized to access requested resource',

--- a/src/enums/Authentication.ts
+++ b/src/enums/Authentication.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum EAuthenticationType {
+export enum AuthenticationType {
 	GUEST = 'GUEST',
 	USER = 'USER',
 	LOGIN = 'LOGIN',

--- a/src/enums/Data.ts
+++ b/src/enums/Data.ts
@@ -3,7 +3,7 @@
  *
  * @internal
  */
-export enum EBaseType {
+export enum BaseType {
 	NOTIFICATION = 'NOTIFICATION',
 	TWEET = 'TWEET',
 	USER = 'USER',

--- a/src/enums/Logging.ts
+++ b/src/enums/Logging.ts
@@ -3,7 +3,7 @@
  *
  * @internal
  */
-export enum ELogActions {
+export enum LogActions {
 	AUTHORIZATION = 'AUTHORIZATION',
 	DESERIALIZE = 'DESERIALIZE',
 	EXTRACT = 'EXTRACT',

--- a/src/enums/Media.ts
+++ b/src/enums/Media.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum EMediaType {
+export enum MediaType {
 	PHOTO = 'PHOTO',
 	VIDEO = 'VIDEO',
 	GIF = 'GIF',

--- a/src/enums/Notification.ts
+++ b/src/enums/Notification.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum ENotificationType {
+export enum NotificationType {
 	RECOMMENDATION = 'RECOMMENDATION',
 	INFORMATION = 'INFORMATION',
 	LIVE = 'LIVE',

--- a/src/enums/Resource.ts
+++ b/src/enums/Resource.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum EResourceType {
+export enum ResourceType {
 	// LIST
 	LIST_MEMBERS = 'LIST_MEMBERS',
 	LIST_TWEETS = 'LIST_TWEETS',

--- a/src/enums/Tweet.ts
+++ b/src/enums/Tweet.ts
@@ -1,7 +1,7 @@
 /**
  * The different types of sorting options when fetching replies to tweets.
  */
-export enum ETweetRepliesSortType {
+export enum TweetRepliesSortType {
 	LIKES = 'LIKES',
 	LATEST = 'LATEST',
 	RELEVANCE = 'RELEVANCE',

--- a/src/enums/raw/Analytics.ts
+++ b/src/enums/raw/Analytics.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum ERawAnalyticsGranularity {
+export enum RawAnalyticsGranularity {
 	DAILY = 'Daily',
 	WEEKLY = 'Weekly',
 	MONTHLY = 'Monthly',
@@ -14,7 +14,7 @@ export enum ERawAnalyticsGranularity {
  *
  * @public
  */
-export enum ERawAnalyticsMetric {
+export enum RawAnalyticsMetric {
 	ENGAGEMENTS = 'Engagements',
 	IMPRESSIONS = 'Impressions',
 	PROFILE_VISITS = 'ProfileVisits',

--- a/src/enums/raw/Media.ts
+++ b/src/enums/raw/Media.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum ERawMediaType {
+export enum RawMediaType {
 	PHOTO = 'photo',
 	VIDEO = 'video',
 	GIF = 'animated_gif',

--- a/src/enums/raw/Notification.ts
+++ b/src/enums/raw/Notification.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum ERawNotificationType {
+export enum RawNotificationType {
 	RECOMMENDATION = 'recommendation_icon',
 	INFORMATION = 'bird_icon',
 	LIVE = 'live_icon',

--- a/src/enums/raw/Tweet.ts
+++ b/src/enums/raw/Tweet.ts
@@ -3,7 +3,7 @@
  *
  * @public
  */
-export enum ERawTweetSearchResultType {
+export enum RawTweetSearchResultType {
 	LATEST = 'Latest',
 	TOP = 'Top',
 }
@@ -13,7 +13,7 @@ export enum ERawTweetSearchResultType {
  *
  * @public
  */
-export enum ERawTweetRepliesSortType {
+export enum RawTweetRepliesSortType {
 	RELEVACE = 'Relevance',
 	LATEST = 'Recency',
 	LIKES = 'Likes',

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -12,7 +12,7 @@ import { IRettiwtConfig } from '../types/RettiwtConfig';
  *
  * @public
  */
-const defaultHeaders = {
+const DefaultHeaders = {
 	/* eslint-disable @typescript-eslint/naming-convention */
 
 	Authority: 'x.com',
@@ -60,7 +60,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this.timeout = config?.timeout;
 		this.apiKey = config?.apiKey;
 		this._headers = {
-			...defaultHeaders,
+			...DefaultHeaders,
 			...config?.headers,
 		};
 	}
@@ -90,7 +90,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 
 	public set headers(headers: { [key: string]: string } | undefined) {
 		this._headers = {
-			...defaultHeaders,
+			...DefaultHeaders,
 			...headers,
 		};
 	}
@@ -100,4 +100,4 @@ export class RettiwtConfig implements IRettiwtConfig {
 	}
 }
 
-export { defaultHeaders as DefaultRettiwtHeaders };
+export { DefaultHeaders as DefaultRettiwtHeaders };

--- a/src/models/args/FetchArgs.ts
+++ b/src/models/args/FetchArgs.ts
@@ -1,4 +1,4 @@
-import { ETweetRepliesSortType } from '../../enums/Tweet';
+import { TweetRepliesSortType } from '../../enums/Tweet';
 import { IFetchArgs, ITweetFilter } from '../../types/args/FetchArgs';
 
 /**
@@ -12,7 +12,7 @@ export class FetchArgs implements IFetchArgs {
 	public filter?: TweetFilter;
 	public id?: string;
 	public ids?: string[];
-	public sortBy?: ETweetRepliesSortType;
+	public sortBy?: TweetRepliesSortType;
 
 	/**
 	 * @param args - Additional user-defined arguments for fetching the resource.
@@ -93,7 +93,7 @@ export class TweetFilter implements ITweetFilter {
 	 * @param date - The date object to convert.
 	 * @returns The Twitter string representation of the date.
 	 */
-	private static dateToTwitterString(date: Date): string {
+	private static _dateToTwitterString(date: Date): string {
 		// Converting localized date to UTC date
 		const utc = new Date(
 			Date.UTC(
@@ -135,8 +135,8 @@ export class TweetFilter implements ITweetFilter {
 				this.minLikes ? `min_faves:${this.minLikes}` : '',
 				this.minRetweets ? `min_retweets:${this.minRetweets}` : '',
 				this.language ? `lang:${this.language}` : '',
-				this.startDate ? `since:${TweetFilter.dateToTwitterString(this.startDate)}` : '',
-				this.endDate ? `until:${TweetFilter.dateToTwitterString(this.endDate)}` : '',
+				this.startDate ? `since:${TweetFilter._dateToTwitterString(this.startDate)}` : '',
+				this.endDate ? `until:${TweetFilter._dateToTwitterString(this.endDate)}` : '',
 				this.sinceId ? `since_id:${this.sinceId}` : '',
 				this.maxId ? `max_id:${this.maxId}` : '',
 				this.quoted ? `quoted_tweet_id:${this.quoted}` : '',

--- a/src/models/auth/AuthCredential.ts
+++ b/src/models/auth/AuthCredential.ts
@@ -2,7 +2,7 @@ import { AxiosHeaders, AxiosRequestHeaders } from 'axios';
 
 import { Cookie } from 'cookiejar';
 
-import { EAuthenticationType } from '../../enums/Authentication';
+import { AuthenticationType } from '../../enums/Authentication';
 import { IAuthCredential } from '../../types/auth/AuthCredential';
 
 import { AuthCookie } from './AuthCookie';
@@ -19,7 +19,7 @@ import { AuthCookie } from './AuthCookie';
  */
 export class AuthCredential implements IAuthCredential {
 	public authToken?: string;
-	public authenticationType?: EAuthenticationType;
+	public authenticationType?: AuthenticationType;
 	public cookies?: string;
 	public csrfToken?: string;
 	public guestToken?: string;
@@ -34,7 +34,7 @@ export class AuthCredential implements IAuthCredential {
 		// If guest credentials given
 		if (!cookies && guestToken) {
 			this.guestToken = guestToken;
-			this.authenticationType = EAuthenticationType.GUEST;
+			this.authenticationType = AuthenticationType.GUEST;
 		}
 		// If login credentials given
 		else if (cookies && guestToken) {
@@ -43,7 +43,7 @@ export class AuthCredential implements IAuthCredential {
 
 			this.cookies = parsedCookie.toString();
 			this.guestToken = guestToken;
-			this.authenticationType = EAuthenticationType.LOGIN;
+			this.authenticationType = AuthenticationType.LOGIN;
 		}
 		// If user credentials given
 		else if (cookies && !guestToken) {
@@ -52,7 +52,7 @@ export class AuthCredential implements IAuthCredential {
 
 			this.cookies = parsedCookie.toString();
 			this.csrfToken = parsedCookie.ct0;
-			this.authenticationType = EAuthenticationType.USER;
+			this.authenticationType = AuthenticationType.USER;
 		}
 	}
 

--- a/src/models/data/CursoredData.ts
+++ b/src/models/data/CursoredData.ts
@@ -1,4 +1,4 @@
-import { EBaseType } from '../../enums/Data';
+import { BaseType } from '../../enums/Data';
 
 import { findByFilter } from '../../helper/JsonUtils';
 
@@ -24,18 +24,18 @@ export class CursoredData<T extends Notification | Tweet | User> implements ICur
 	 * @param response - The raw response.
 	 * @param type - The base type of the data included in the batch.
 	 */
-	public constructor(response: NonNullable<unknown>, type: EBaseType) {
+	public constructor(response: NonNullable<unknown>, type: BaseType) {
 		// Initializing defaults
 		this.list = [];
 		this.next = '';
 
-		if (type == EBaseType.TWEET) {
+		if (type == BaseType.TWEET) {
 			this.list = Tweet.timeline(response) as T[];
 			this.next = findByFilter<IRawCursor>(response, 'cursorType', 'Bottom')[0]?.value ?? '';
-		} else if (type == EBaseType.USER) {
+		} else if (type == BaseType.USER) {
 			this.list = User.timeline(response) as T[];
 			this.next = findByFilter<IRawCursor>(response, 'cursorType', 'Bottom')[0]?.value ?? '';
-		} else if (type == EBaseType.NOTIFICATION) {
+		} else if (type == BaseType.NOTIFICATION) {
 			this.list = Notification.list(response) as T[];
 			this.next = findByFilter<IRawCursor>(response, 'cursorType', 'Top')[0]?.value ?? '';
 		}

--- a/src/models/data/Notification.ts
+++ b/src/models/data/Notification.ts
@@ -1,5 +1,5 @@
-import { ENotificationType } from '../../enums/Notification';
-import { ERawNotificationType } from '../../enums/raw/Notification';
+import { NotificationType } from '../../enums/Notification';
+import { RawNotificationType } from '../../enums/raw/Notification';
 import { findKeyByValue } from '../../helper/JsonUtils';
 import { INotification } from '../../types/data/Notification';
 import { INotification as IRawNotification } from '../../types/raw/base/Notification';
@@ -19,7 +19,7 @@ export class Notification implements INotification {
 	public message: string;
 	public receivedAt: string;
 	public target: string[];
-	public type?: ENotificationType;
+	public type?: NotificationType;
 
 	/**
 	 * @param notification - The raw notification details.
@@ -28,7 +28,7 @@ export class Notification implements INotification {
 		this._raw = { ...notification };
 
 		// Getting the original notification type
-		const notificationType: string | undefined = findKeyByValue(ERawNotificationType, notification.icon.id);
+		const notificationType: string | undefined = findKeyByValue(RawNotificationType, notification.icon.id);
 
 		this.from = notification.template?.aggregateUserActionsV1?.fromUsers
 			? notification.template.aggregateUserActionsV1.fromUsers.map((item) => item.user.id)
@@ -40,8 +40,8 @@ export class Notification implements INotification {
 			? notification.template.aggregateUserActionsV1.targetObjects.map((item) => item.tweet.id)
 			: [];
 		this.type = notificationType
-			? ENotificationType[notificationType as keyof typeof ENotificationType]
-			: ENotificationType.UNDEFINED;
+			? NotificationType[notificationType as keyof typeof NotificationType]
+			: NotificationType.UNDEFINED;
 	}
 
 	/** The raw notification details. */

--- a/src/models/data/Tweet.ts
+++ b/src/models/data/Tweet.ts
@@ -1,6 +1,6 @@
-import { ELogActions } from '../../enums/Logging';
-import { EMediaType } from '../../enums/Media';
-import { ERawMediaType } from '../../enums/raw/Media';
+import { LogActions } from '../../enums/Logging';
+import { MediaType } from '../../enums/Media';
+import { RawMediaType } from '../../enums/raw/Media';
 import { findByFilter } from '../../helper/JsonUtils';
 
 import { LogService } from '../../services/internal/LogService';
@@ -52,7 +52,7 @@ export class Tweet implements ITweet {
 		this.tweetBy = new User(tweet.core.user_results.result);
 		this.entities = new TweetEntities(tweet.legacy.entities);
 		this.media = tweet.legacy.extended_entities?.media?.map((media) => new TweetMedia(media));
-		this.quoted = this.getQuotedTweet(tweet);
+		this.quoted = this._getQuotedTweet(tweet);
 		this.fullText = tweet.note_tweet ? tweet.note_tweet.note_tweet_results.result.text : tweet.legacy.full_text;
 		this.replyTo = tweet.legacy.in_reply_to_status_id_str;
 		this.lang = tweet.legacy.lang;
@@ -62,7 +62,7 @@ export class Tweet implements ITweet {
 		this.likeCount = tweet.legacy.favorite_count;
 		this.viewCount = tweet.views.count ? parseInt(tweet.views.count) : 0;
 		this.bookmarkCount = tweet.legacy.bookmark_count;
-		this.retweetedTweet = this.getRetweetedTweet(tweet);
+		this.retweetedTweet = this._getRetweetedTweet(tweet);
 		this.url = `https://x.com/${this.tweetBy.userName}/status/${this.id}`;
 	}
 
@@ -78,7 +78,7 @@ export class Tweet implements ITweet {
 	 *
 	 * @returns - The deserialized original quoted tweet.
 	 */
-	private getQuotedTweet(tweet: IRawTweet): Tweet | undefined {
+	private _getQuotedTweet(tweet: IRawTweet): Tweet | undefined {
 		// If tweet with limited visibility
 		if (
 			tweet.quoted_status_result &&
@@ -104,7 +104,7 @@ export class Tweet implements ITweet {
 	 *
 	 * @returns - The deserialized original retweeted tweet.
 	 */
-	private getRetweetedTweet(tweet: IRawTweet): Tweet | undefined {
+	private _getRetweetedTweet(tweet: IRawTweet): Tweet | undefined {
 		// If retweet with limited visibility
 		if (
 			tweet.legacy?.retweeted_status_result &&
@@ -141,13 +141,13 @@ export class Tweet implements ITweet {
 		for (const item of extract) {
 			if (item.legacy) {
 				// Logging
-				LogService.log(ELogActions.DESERIALIZE, { id: item.rest_id });
+				LogService.log(LogActions.DESERIALIZE, { id: item.rest_id });
 
 				tweets.push(new Tweet(item));
 			} else {
 				// Logging
-				LogService.log(ELogActions.WARNING, {
-					action: ELogActions.DESERIALIZE,
+				LogService.log(LogActions.WARNING, {
+					action: LogActions.DESERIALIZE,
 					message: `Tweet not found, skipping`,
 				});
 			}
@@ -179,13 +179,13 @@ export class Tweet implements ITweet {
 		for (const item of extract) {
 			if (item.legacy) {
 				// Logging
-				LogService.log(ELogActions.DESERIALIZE, { id: item.rest_id });
+				LogService.log(LogActions.DESERIALIZE, { id: item.rest_id });
 
 				tweets.push(new Tweet(item));
 			} else {
 				// Logging
-				LogService.log(ELogActions.WARNING, {
-					action: ELogActions.DESERIALIZE,
+				LogService.log(LogActions.WARNING, {
+					action: LogActions.DESERIALIZE,
 					message: `Tweet not found, skipping`,
 				});
 			}
@@ -221,15 +221,15 @@ export class Tweet implements ITweet {
 			// If normal tweet
 			else if ((item.tweet_results?.result as IRawTweet)?.legacy) {
 				// Logging
-				LogService.log(ELogActions.DESERIALIZE, { id: (item.tweet_results.result as IRawTweet).rest_id });
+				LogService.log(LogActions.DESERIALIZE, { id: (item.tweet_results.result as IRawTweet).rest_id });
 
 				tweets.push(new Tweet(item.tweet_results.result as IRawTweet));
 			}
 			// If invalid/unrecognized tweet
 			else {
 				// Logging
-				LogService.log(ELogActions.WARNING, {
-					action: ELogActions.DESERIALIZE,
+				LogService.log(LogActions.WARNING, {
+					action: LogActions.DESERIALIZE,
 					message: `Tweet not found, skipping`,
 				});
 			}
@@ -328,7 +328,7 @@ export class TweetMedia {
 	public thumbnailUrl?: string;
 
 	/** The type of media. */
-	public type: EMediaType;
+	public type: MediaType;
 
 	/** The direct URL to the media. */
 	public url = '';
@@ -338,18 +338,18 @@ export class TweetMedia {
 	 */
 	public constructor(media: IRawExtendedMedia) {
 		// If the media is a photo
-		if (media.type == ERawMediaType.PHOTO) {
-			this.type = EMediaType.PHOTO;
+		if (media.type == RawMediaType.PHOTO) {
+			this.type = MediaType.PHOTO;
 			this.url = media.media_url_https;
 		}
 		// If the media is a gif
-		else if (media.type == ERawMediaType.GIF) {
-			this.type = EMediaType.GIF;
+		else if (media.type == RawMediaType.GIF) {
+			this.type = MediaType.GIF;
 			this.url = media.video_info?.variants[0].url as string;
 		}
 		// If the media is a video
 		else {
-			this.type = EMediaType.VIDEO;
+			this.type = MediaType.VIDEO;
 			this.thumbnailUrl = media.media_url_https;
 
 			/** The highest bitrate of all variants. */

--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -1,4 +1,4 @@
-import { ELogActions } from '../../enums/Logging';
+import { LogActions } from '../../enums/Logging';
 import { findByFilter } from '../../helper/JsonUtils';
 import { LogService } from '../../services/internal/LogService';
 import { IUser } from '../../types/data/User';
@@ -73,13 +73,13 @@ export class User implements IUser {
 		for (const item of extract) {
 			if (item.legacy && item.legacy.created_at) {
 				// Logging
-				LogService.log(ELogActions.DESERIALIZE, { id: item.rest_id });
+				LogService.log(LogActions.DESERIALIZE, { id: item.rest_id });
 
 				users.push(new User(item));
 			} else {
 				// Logging
-				LogService.log(ELogActions.WARNING, {
-					action: ELogActions.DESERIALIZE,
+				LogService.log(LogActions.WARNING, {
+					action: LogActions.DESERIALIZE,
 					message: `User not found, skipping`,
 				});
 			}
@@ -110,13 +110,13 @@ export class User implements IUser {
 		for (const item of extract) {
 			if (item.legacy && item.legacy.created_at) {
 				// Logging
-				LogService.log(ELogActions.DESERIALIZE, { id: item.rest_id });
+				LogService.log(LogActions.DESERIALIZE, { id: item.rest_id });
 
 				users.push(new User(item));
 			} else {
 				// Logging
-				LogService.log(ELogActions.WARNING, {
-					action: ELogActions.DESERIALIZE,
+				LogService.log(LogActions.WARNING, {
+					action: LogActions.DESERIALIZE,
 					message: `User not found, skipping`,
 				});
 			}
@@ -142,13 +142,13 @@ export class User implements IUser {
 		for (const item of extract) {
 			if (item.user_results?.result?.legacy) {
 				// Logging
-				LogService.log(ELogActions.DESERIALIZE, { id: item.user_results.result.rest_id });
+				LogService.log(LogActions.DESERIALIZE, { id: item.user_results.result.rest_id });
 
 				users.push(new User(item.user_results.result));
 			} else {
 				// Logging
-				LogService.log(ELogActions.WARNING, {
-					action: ELogActions.DESERIALIZE,
+				LogService.log(LogActions.WARNING, {
+					action: LogActions.DESERIALIZE,
 					message: `User not found, skipping`,
 				});
 			}

--- a/src/requests/Tweet.ts
+++ b/src/requests/Tweet.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from 'axios';
 
-import { ERawTweetRepliesSortType, ERawTweetSearchResultType } from '../enums/raw/Tweet';
+import { RawTweetRepliesSortType, RawTweetSearchResultType } from '../enums/raw/Tweet';
 import { TweetFilter } from '../models/args/FetchArgs';
 import { NewTweet } from '../models/args/PostArgs';
 import { MediaVariable, ReplyVariable } from '../models/params/Variables';
@@ -266,7 +266,7 @@ export class TweetRequests {
 	 * @param id - The id of the tweet whose replies are to be fetched.
 	 * @param cursor - The cursor to the batch of replies to fetch.
 	 */
-	public static replies(id: string, cursor?: string, sortBy?: ERawTweetRepliesSortType): AxiosRequestConfig {
+	public static replies(id: string, cursor?: string, sortBy?: RawTweetRepliesSortType): AxiosRequestConfig {
 		return {
 			method: 'get',
 			url: 'https://x.com/i/api/graphql/_8aYOgEDz35BrBcBal1-_w/TweetDetail',
@@ -277,7 +277,7 @@ export class TweetRequests {
 					cursor: cursor,
 					referrer: 'tweet',
 					with_rux_injections: false,
-					rankingMode: sortBy ?? ERawTweetRepliesSortType.RELEVACE,
+					rankingMode: sortBy ?? RawTweetRepliesSortType.RELEVACE,
 					includePromotedContent: true,
 					withCommunity: true,
 					withQuickPromoteEligibilityTweetFields: true,
@@ -451,7 +451,7 @@ export class TweetRequests {
 					count: count,
 					cursor: cursor,
 					querySource: 'typed_query',
-					product: parsedFilter.top ? ERawTweetSearchResultType.TOP : ERawTweetSearchResultType.LATEST,
+					product: parsedFilter.top ? RawTweetSearchResultType.TOP : RawTweetSearchResultType.LATEST,
 					withAuxiliaryUserLabels: false,
 					withArticleRichContentState: false,
 					withArticlePlainText: false,

--- a/src/requests/User.ts
+++ b/src/requests/User.ts
@@ -2,7 +2,7 @@ import qs from 'querystring';
 
 import { AxiosRequestConfig } from 'axios';
 
-import { ERawAnalyticsGranularity, ERawAnalyticsMetric } from '../enums/raw/Analytics';
+import { RawAnalyticsGranularity, RawAnalyticsMetric } from '../enums/raw/Analytics';
 
 /**
  * Collection of requests related to users.
@@ -77,8 +77,8 @@ export class UserRequests {
 	public static analytics(
 		fromTime: Date,
 		toTime: Date,
-		granularity: ERawAnalyticsGranularity,
-		requestedMetrics: ERawAnalyticsMetric[],
+		granularity: RawAnalyticsGranularity,
+		requestedMetrics: RawAnalyticsMetric[],
 	): AxiosRequestConfig {
 		return {
 			method: 'get',

--- a/src/services/internal/AuthService.ts
+++ b/src/services/internal/AuthService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { EApiErrors } from '../../enums/Api';
+import { ApiErrors } from '../../enums/Api';
 import { AuthCredential } from '../../models/auth/AuthCredential';
 import { RettiwtConfig } from '../../models/RettiwtConfig';
 
@@ -67,7 +67,7 @@ export class AuthService {
 		}
 		// If user id was not found
 		else {
-			throw new Error(EApiErrors.BAD_AUTHENTICATION);
+			throw new Error(ApiErrors.BAD_AUTHENTICATION);
 		}
 	}
 

--- a/src/services/internal/ErrorService.ts
+++ b/src/services/internal/ErrorService.ts
@@ -15,14 +15,14 @@ export class ErrorService implements IErrorHandler {
 	 *
 	 * @param error - The error response received from Twitter.
 	 */
-	private handleAxiosError(error: AxiosError<IRawErrorData | IRawErrorDetails>): void {
+	private _handleAxiosError(error: AxiosError<IRawErrorData | IRawErrorDetails>): void {
 		throw new TwitterError(error);
 	}
 
 	/**
 	 * Handle unknown error.
 	 */
-	private handleUnknownError(): void {
+	private _handleUnknownError(): void {
 		throw new Error('Unknown error');
 	}
 
@@ -33,9 +33,9 @@ export class ErrorService implements IErrorHandler {
 	 */
 	public handle(error: unknown): void {
 		if (isAxiosError(error)) {
-			this.handleAxiosError(error as AxiosError<IRawErrorData | IRawErrorDetails>);
+			this._handleAxiosError(error as AxiosError<IRawErrorData | IRawErrorDetails>);
 		} else {
-			this.handleUnknownError();
+			this._handleUnknownError();
 		}
 	}
 }

--- a/src/services/internal/LogService.ts
+++ b/src/services/internal/LogService.ts
@@ -1,4 +1,4 @@
-import { ELogActions } from '../../enums/Logging';
+import { LogActions } from '../../enums/Logging';
 
 /**
  * Handles logging of data for debug purpose.
@@ -16,7 +16,7 @@ export class LogService {
 	 *
 	 * @param data - The data to be logged.
 	 */
-	public static log(action: ELogActions, data: NonNullable<unknown>): void {
+	public static log(action: LogActions, data: NonNullable<unknown>): void {
 		// Proceed to log only if logging is enabled
 		if (this.enabled) {
 			// Preparing the log message

--- a/src/services/public/ListService.ts
+++ b/src/services/public/ListService.ts
@@ -1,5 +1,5 @@
-import { extractors } from '../../collections/Extractors';
-import { EResourceType } from '../../enums/Resource';
+import { Extractors } from '../../collections/Extractors';
+import { ResourceType } from '../../enums/Resource';
 import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
@@ -49,7 +49,7 @@ export class ListService extends FetcherService {
 	 * @remarks Due a bug in Twitter API, the count is ignored when no cursor is provided and defaults to 100.
 	 */
 	public async members(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource: EResourceType = EResourceType.LIST_MEMBERS;
+		const resource: ResourceType = ResourceType.LIST_MEMBERS;
 
 		// Fetching the raw list of members
 		const response = await this.request<IListMembersResponse>(resource, {
@@ -59,7 +59,7 @@ export class ListService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -94,7 +94,7 @@ export class ListService extends FetcherService {
 	 * @remarks Due a bug in Twitter API, the count is ignored when no cursor is provided and defaults to 100.
 	 */
 	public async tweets(id: string, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.LIST_TWEETS;
+		const resource = ResourceType.LIST_TWEETS;
 
 		// Fetching raw list tweets
 		const response = await this.request<IListTweetsResponse>(resource, {
@@ -104,7 +104,7 @@ export class ListService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		// Sorting the tweets by date, from recent to oldest
 		data.list.sort((a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf());

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -1,8 +1,8 @@
 import { statSync } from 'fs';
 
-import { extractors } from '../../collections/Extractors';
-import { EResourceType } from '../../enums/Resource';
-import { ETweetRepliesSortType } from '../../enums/Tweet';
+import { Extractors } from '../../collections/Extractors';
+import { ResourceType } from '../../enums/Resource';
+import { TweetRepliesSortType } from '../../enums/Tweet';
 import { CursoredData } from '../../models/data/CursoredData';
 import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
@@ -95,41 +95,41 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async details<T extends string | string[]>(id: T): Promise<T extends string ? Tweet | undefined : Tweet[]> {
-		let resource: EResourceType;
+		let resource: ResourceType;
 
 		// If user is authenticated and details of single tweet required
 		if (this.config.userId != undefined && typeof id == 'string') {
-			resource = EResourceType.TWEET_DETAILS_ALT;
+			resource = ResourceType.TWEET_DETAILS_ALT;
 
 			// Fetching raw tweet details
 			const response = await this.request<ITweetRepliesResponse>(resource, { id: id });
 
 			// Deserializing response
-			const data = extractors[resource](response, id);
+			const data = Extractors[resource](response, id);
 
 			return data as T extends string ? Tweet | undefined : Tweet[];
 		}
 		// If user is authenticated and details of multiple tweets required
 		else if (this.config.userId != undefined && Array.isArray(id)) {
-			resource = EResourceType.TWEET_DETAILS_BULK;
+			resource = ResourceType.TWEET_DETAILS_BULK;
 
 			// Fetching raw tweet details
 			const response = await this.request<ITweetDetailsBulkResponse>(resource, { ids: id });
 
 			// Deserializing response
-			const data = extractors[resource](response, id);
+			const data = Extractors[resource](response, id);
 
 			return data as T extends string ? Tweet | undefined : Tweet[];
 		}
 		// If user is not authenticated
 		else {
-			resource = EResourceType.TWEET_DETAILS;
+			resource = ResourceType.TWEET_DETAILS;
 
 			// Fetching raw tweet details
 			const response = await this.request<ITweetDetailsResponse>(resource, { id: String(id) });
 
 			// Deserializing response
-			const data = extractors[resource](response, String(id));
+			const data = Extractors[resource](response, String(id));
 
 			return data as T extends string ? Tweet | undefined : Tweet[];
 		}
@@ -161,7 +161,7 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async like(id: string): Promise<boolean> {
-		const resource = EResourceType.TWEET_LIKE;
+		const resource = ResourceType.TWEET_LIKE;
 
 		// Favoriting the tweet
 		const response = await this.request<ITweetLikeResponse>(resource, {
@@ -169,7 +169,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -202,7 +202,7 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async likers(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource = EResourceType.TWEET_LIKERS;
+		const resource = ResourceType.TWEET_LIKERS;
 
 		// Fetching raw likers
 		const response = await this.request<ITweetLikersResponse>(resource, {
@@ -212,7 +212,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -301,13 +301,13 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async post(options: INewTweet): Promise<string | undefined> {
-		const resource = EResourceType.TWEET_POST;
+		const resource = ResourceType.TWEET_POST;
 
 		// Posting the tweet
 		const response = await this.request<ITweetPostResponse>(resource, { tweet: options });
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -317,7 +317,7 @@ export class TweetService extends FetcherService {
 	 *
 	 * @param id - The ID of the target tweet.
 	 * @param cursor - The cursor to the batch of replies to fetch.
-	 * @param sortBy - The sorting order of the replies to fetch. Default is {@link ETweetRepliesSortType.RECENT}.
+	 * @param sortBy - The sorting order of the replies to fetch. Default is {@link TweetRepliesSortType.RECENT}.
 	 *
 	 * @returns The list of replies to the given tweet.
 	 *
@@ -346,9 +346,9 @@ export class TweetService extends FetcherService {
 	public async replies(
 		id: string,
 		cursor?: string,
-		sortBy: ETweetRepliesSortType = ETweetRepliesSortType.LATEST,
+		sortBy: TweetRepliesSortType = TweetRepliesSortType.LATEST,
 	): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.TWEET_REPLIES;
+		const resource = ResourceType.TWEET_REPLIES;
 
 		// Fetching raw list of replies
 		const response = await this.request<ITweetDetailsResponse>(resource, {
@@ -358,7 +358,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -389,13 +389,13 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async retweet(id: string): Promise<boolean> {
-		const resource = EResourceType.TWEET_RETWEET;
+		const resource = ResourceType.TWEET_RETWEET;
 
 		// Retweeting the tweet
 		const response = await this.request<ITweetRetweetResponse>(resource, { id: id });
 
 		// Deserializing response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -428,7 +428,7 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async retweeters(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource = EResourceType.TWEET_RETWEETERS;
+		const resource = ResourceType.TWEET_RETWEETERS;
 
 		// Fetching raw list of retweeters
 		const response = await this.request<ITweetRetweetersResponse>(resource, {
@@ -438,7 +438,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -474,13 +474,13 @@ export class TweetService extends FetcherService {
 	 * Scheduling a tweet is similar to {@link post}ing, except that an extra parameter called `scheduleFor` is used.
 	 */
 	public async schedule(options: INewTweet): Promise<string | undefined> {
-		const resource = EResourceType.TWEET_SCHEDULE;
+		const resource = ResourceType.TWEET_SCHEDULE;
 
 		// Scheduling the tweet
 		const response = await this.request<ITweetScheduleResponse>(resource, { tweet: options });
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -518,7 +518,7 @@ export class TweetService extends FetcherService {
 	 * For details about available filters, refer to {@link TweetFilter}
 	 */
 	public async search(filter: ITweetFilter, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.TWEET_SEARCH;
+		const resource = ResourceType.TWEET_SEARCH;
 
 		// Fetching raw list of filtered tweets
 		const response = await this.request<ITweetSearchResponse>(resource, {
@@ -528,7 +528,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		// Sorting the tweets by date, from recent to oldest
 		data.list.sort((a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf());
@@ -631,13 +631,13 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async unlike(id: string): Promise<boolean> {
-		const resource = EResourceType.TWEET_UNLIKE;
+		const resource = ResourceType.TWEET_UNLIKE;
 
 		// Unliking the tweet
 		const response = await this.request<ITweetUnlikeResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -668,13 +668,13 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async unpost(id: string): Promise<boolean> {
-		const resource = EResourceType.TWEET_UNPOST;
+		const resource = ResourceType.TWEET_UNPOST;
 
 		// Unposting the tweet
 		const response = await this.request<ITweetUnpostResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -705,13 +705,13 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async unretweet(id: string): Promise<boolean> {
-		const resource = EResourceType.TWEET_UNRETWEET;
+		const resource = ResourceType.TWEET_UNRETWEET;
 
 		// Unretweeting the tweet
 		const response = await this.request<ITweetUnretweetResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -742,13 +742,13 @@ export class TweetService extends FetcherService {
 	 * ```
 	 */
 	public async unschedule(id: string): Promise<boolean> {
-		const resource = EResourceType.TWEET_UNSCHEDULE;
+		const resource = ResourceType.TWEET_UNSCHEDULE;
 
 		// Unscheduling the tweet
 		const response = await this.request<ITweetUnscheduleResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -788,16 +788,16 @@ export class TweetService extends FetcherService {
 		// INITIALIZE
 		const size = typeof media == 'string' ? statSync(media).size : media.byteLength;
 		const id: string = (
-			await this.request<IMediaInitializeUploadResponse>(EResourceType.MEDIA_UPLOAD_INITIALIZE, {
+			await this.request<IMediaInitializeUploadResponse>(ResourceType.MEDIA_UPLOAD_INITIALIZE, {
 				upload: { size: size },
 			})
 		).media_id_string;
 
 		// APPEND
-		await this.request<unknown>(EResourceType.MEDIA_UPLOAD_APPEND, { upload: { id: id, media: media } });
+		await this.request<unknown>(ResourceType.MEDIA_UPLOAD_APPEND, { upload: { id: id, media: media } });
 
 		// FINALIZE
-		await this.request<unknown>(EResourceType.MEDIA_UPLOAD_FINALIZE, { upload: { id: id } });
+		await this.request<unknown>(ResourceType.MEDIA_UPLOAD_FINALIZE, { upload: { id: id } });
 
 		return id;
 	}

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -1,5 +1,5 @@
-import { extractors } from '../../collections/Extractors';
-import { EResourceType } from '../../enums/Resource';
+import { Extractors } from '../../collections/Extractors';
+import { ResourceType } from '../../enums/Resource';
 import { CursoredData } from '../../models/data/CursoredData';
 import { Notification } from '../../models/data/Notification';
 import { Tweet } from '../../models/data/Tweet';
@@ -68,7 +68,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async affiliates(id?: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource = EResourceType.USER_AFFILIATES;
+		const resource = ResourceType.USER_AFFILIATES;
 
 		// Fetching raw list of affiliates
 		const response = await this.request<IUserAffiliatesResponse>(resource, {
@@ -78,7 +78,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -110,7 +110,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async bookmarks(count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_BOOKMARKS;
+		const resource = ResourceType.USER_BOOKMARKS;
 
 		// Fetching raw list of likes
 		const response = await this.request<IUserBookmarksResponse>(resource, {
@@ -119,7 +119,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -195,17 +195,17 @@ export class UserService extends FetcherService {
 	public async details<T extends string | string[] | undefined>(
 		id: T,
 	): Promise<T extends string | undefined ? User | undefined : User[]> {
-		let resource: EResourceType;
+		let resource: ResourceType;
 
 		// If details of multiple users required
 		if (Array.isArray(id)) {
-			resource = EResourceType.USER_DETAILS_BY_IDS_BULK;
+			resource = ResourceType.USER_DETAILS_BY_IDS_BULK;
 
 			// Fetching raw details
 			const response = await this.request<IUserDetailsBulkResponse>(resource, { ids: id });
 
 			// Deserializing response
-			const data = extractors[resource](response, id);
+			const data = Extractors[resource](response, id);
 
 			return data as T extends string | undefined ? User | undefined : User[];
 		}
@@ -213,11 +213,11 @@ export class UserService extends FetcherService {
 		else {
 			// If username is given
 			if (id && isNaN(Number(id))) {
-				resource = EResourceType.USER_DETAILS_BY_USERNAME;
+				resource = ResourceType.USER_DETAILS_BY_USERNAME;
 			}
 			// If id is given (or not, for self details)
 			else {
-				resource = EResourceType.USER_DETAILS_BY_ID;
+				resource = ResourceType.USER_DETAILS_BY_ID;
 			}
 
 			// If no ID is given, and not authenticated, skip
@@ -229,7 +229,7 @@ export class UserService extends FetcherService {
 			const response = await this.request<IUserDetailsResponse>(resource, { id: id ?? this.config.userId });
 
 			// Deserializing response
-			const data = extractors[resource](response);
+			const data = Extractors[resource](response);
 
 			return data as T extends string | undefined ? User | undefined : User[];
 		}
@@ -263,13 +263,13 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async follow(id: string): Promise<boolean> {
-		const resource = EResourceType.USER_FOLLOW;
+		const resource = ResourceType.USER_FOLLOW;
 
 		// Following the user
-		const response = await this.request<IUserFollowResponse>(EResourceType.USER_FOLLOW, { id: id });
+		const response = await this.request<IUserFollowResponse>(ResourceType.USER_FOLLOW, { id: id });
 
 		// Deserializing the response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}
@@ -302,7 +302,7 @@ export class UserService extends FetcherService {
 	 * @remarks Always returns 35 feed items, with no way to customize the count.
 	 */
 	public async followed(cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_FEED_FOLLOWED;
+		const resource = ResourceType.USER_FEED_FOLLOWED;
 
 		// Fetching raw list of tweets
 		const response = await this.request<IUserFollowedResponse>(resource, {
@@ -310,7 +310,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -343,7 +343,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async followers(id?: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource = EResourceType.USER_FOLLOWERS;
+		const resource = ResourceType.USER_FOLLOWERS;
 
 		// Fetching raw list of followers
 		const response = await this.request<IUserFollowersResponse>(resource, {
@@ -353,7 +353,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -386,7 +386,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async following(id?: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource = EResourceType.USER_FOLLOWING;
+		const resource = ResourceType.USER_FOLLOWING;
 
 		// Fetching raw list of following
 		const response = await this.request<IUserFollowingResponse>(resource, {
@@ -396,7 +396,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -429,7 +429,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async highlights(id: string, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_HIGHLIGHTS;
+		const resource = ResourceType.USER_HIGHLIGHTS;
 
 		// Fetching raw list of highlights
 		const response = await this.request<IUserHighlightsResponse>(resource, {
@@ -439,7 +439,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -471,7 +471,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async likes(count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_LIKES;
+		const resource = ResourceType.USER_LIKES;
 
 		// Fetching raw list of likes
 		const response = await this.request<IUserLikesResponse>(resource, {
@@ -481,7 +481,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -514,7 +514,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async media(id?: string, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_MEDIA;
+		const resource = ResourceType.USER_MEDIA;
 
 		// Fetching raw list of media
 		const response = await this.request<IUserMediaResponse>(resource, {
@@ -524,7 +524,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -562,7 +562,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async *notifications(pollingInterval = 60000): AsyncGenerator<Notification> {
-		const resource = EResourceType.USER_NOTIFICATIONS;
+		const resource = ResourceType.USER_NOTIFICATIONS;
 
 		/** Whether it's the first batch of notifications or not. */
 		let first = true;
@@ -581,7 +581,7 @@ export class UserService extends FetcherService {
 			});
 
 			// Deserializing response
-			const notifications = extractors[resource](response);
+			const notifications = Extractors[resource](response);
 
 			// Sorting the notifications by time, from oldest to recent
 			notifications.list.sort((a, b) => new Date(a.receivedAt).valueOf() - new Date(b.receivedAt).valueOf());
@@ -630,7 +630,7 @@ export class UserService extends FetcherService {
 	 * @remarks Always returns 35 feed items, with no way to customize the count.
 	 */
 	public async recommended(cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_FEED_RECOMMENDED;
+		const resource = ResourceType.USER_FEED_RECOMMENDED;
 
 		// Fetching raw list of tweets
 		const response = await this.request<IUserRecommendedResponse>(resource, {
@@ -638,7 +638,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -675,7 +675,7 @@ export class UserService extends FetcherService {
 	 * If the target user has a pinned tweet, the returned reply timeline has one item extra and this is always the pinned tweet.
 	 */
 	public async replies(id?: string, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_TIMELINE_AND_REPLIES;
+		const resource = ResourceType.USER_TIMELINE_AND_REPLIES;
 
 		// Fetching raw list of replies
 		const response = await this.request<IUserTweetsAndRepliesResponse>(resource, {
@@ -685,7 +685,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -720,7 +720,7 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async subscriptions(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
-		const resource = EResourceType.USER_SUBSCRIPTIONS;
+		const resource = ResourceType.USER_SUBSCRIPTIONS;
 
 		// Fetching raw list of subscriptions
 		const response = await this.request<IUserSubscriptionsResponse>(resource, {
@@ -730,7 +730,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -768,7 +768,7 @@ export class UserService extends FetcherService {
 	 * - If timeline is fetched without authenticating, then the most popular tweets of the target user are returned instead.
 	 */
 	public async timeline(id: string, count?: number, cursor?: string): Promise<CursoredData<Tweet>> {
-		const resource = EResourceType.USER_TIMELINE;
+		const resource = ResourceType.USER_TIMELINE;
 
 		// Fetching raw list of tweets
 		const response = await this.request<IUserTweetsResponse>(resource, {
@@ -778,7 +778,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = extractors[resource](response);
+		const data = Extractors[resource](response);
 
 		return data;
 	}
@@ -809,13 +809,13 @@ export class UserService extends FetcherService {
 	 * ```
 	 */
 	public async unfollow(id: string): Promise<boolean> {
-		const resource = EResourceType.USER_UNFOLLOW;
+		const resource = ResourceType.USER_UNFOLLOW;
 
 		// Unfollowing the user
-		const response = await this.request<IUserUnfollowResponse>(EResourceType.USER_UNFOLLOW, { id: id });
+		const response = await this.request<IUserUnfollowResponse>(ResourceType.USER_UNFOLLOW, { id: id });
 
 		// Deserializing the response
-		const data = extractors[resource](response) ?? false;
+		const data = Extractors[resource](response) ?? false;
 
 		return data;
 	}

--- a/src/types/args/FetchArgs.ts
+++ b/src/types/args/FetchArgs.ts
@@ -1,4 +1,4 @@
-import { ETweetRepliesSortType } from '../../enums/Tweet';
+import { TweetRepliesSortType } from '../../enums/Tweet';
 
 /**
  * Options specifying the data that is to be fetched.
@@ -64,7 +64,7 @@ export interface IFetchArgs {
 	 * @remarks
 	 * - Only works for {@link EResourceType.TWEET_REPLIES}.
 	 */
-	sortBy?: ETweetRepliesSortType;
+	sortBy?: TweetRepliesSortType;
 }
 
 /**

--- a/src/types/auth/AuthCredential.ts
+++ b/src/types/auth/AuthCredential.ts
@@ -1,4 +1,4 @@
-import { EAuthenticationType } from '../../enums/Authentication';
+import { AuthenticationType } from '../../enums/Authentication';
 
 /**
  * The credentials for authenticating against Twitter.
@@ -15,7 +15,7 @@ export interface IAuthCredential {
 	authToken?: string;
 
 	/** The type of authentication. */
-	authenticationType?: EAuthenticationType;
+	authenticationType?: AuthenticationType;
 
 	/** The cookie of the twitter account, which is used to authenticate against twitter. */
 	cookies?: string;

--- a/src/types/data/Notification.ts
+++ b/src/types/data/Notification.ts
@@ -1,4 +1,4 @@
-import { ENotificationType } from '../../enums/Notification';
+import { NotificationType } from '../../enums/Notification';
 
 /**
  * The details of a single notification.
@@ -22,5 +22,5 @@ export interface INotification {
 	target: string[];
 
 	/** The type of notification. */
-	type?: ENotificationType;
+	type?: NotificationType;
 }

--- a/src/types/data/Tweet.ts
+++ b/src/types/data/Tweet.ts
@@ -1,4 +1,4 @@
-import { EMediaType } from '../../enums/Media';
+import { MediaType } from '../../enums/Media';
 
 import { IUser } from './User';
 
@@ -89,7 +89,7 @@ export interface ITweetMedia {
 	thumbnailUrl?: string;
 
 	/** The type of media. */
-	type: EMediaType;
+	type: MediaType;
 
 	/** The direct URL to the media. */
 	url: string;

--- a/src/types/raw/base/Media.ts
+++ b/src/types/raw/base/Media.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import { ERawMediaType } from '../../../enums/raw/Media';
+import { RawMediaType } from '../../../enums/raw/Media';
 
 /**
  * Represents the raw data of a single Media.
@@ -12,7 +12,7 @@ export interface IMedia {
 	expanded_url: string;
 	id_str: string;
 	media_url_https: string;
-	type: ERawMediaType;
+	type: RawMediaType;
 	url: string;
 }
 

--- a/src/types/raw/base/Notification.ts
+++ b/src/types/raw/base/Notification.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import { ERawNotificationType } from '../../../enums/raw/Notification';
+import { RawNotificationType } from '../../../enums/raw/Notification';
 
 /**
  * Represents the raw data of a single Notification.
@@ -16,7 +16,7 @@ export interface INotification {
 }
 
 export interface INotificationIcon {
-	id: ERawNotificationType;
+	id: RawNotificationType;
 }
 
 export interface INotificationMessage {


### PR DESCRIPTION
All enums have been renamed, with the new name being the old name with the prefix 'E' removed i.e, `EResourceType` becomes `ResourceType`, an so on.

The following enums are changed:

- `EApiErrors` -> `ApiErrors`
- `EAuthenticationType` -> `AuthenticationType`
- `EBaseType` -> `BaseType`
- `ELogActions` -> `LogActions`
- `EMediaType` -> `MediaType`
- `ENotificationType` -> `NotificationType`
- `EResourceType` -> `ResourceType`
- `ETweetRepliesSortType` -> `TweetRepliesSortType`
- `ERawAnalyticsGranularity` -> `RawAnalyticsGranularity`
- `ERawAnalyticsMetric` -> `RawAnalyticsMetric`
- `ERawMediaType` -> `RawMediaType`
- `ERawNotificationType` -> `RawNotificationType`
- `ERawTweetSearchResultType` -> `RawTweetSearchResultType`
- `ERawTweetRepliesSortType` -> `RawTweetRepliesSortType`