### PR TITLE
Added ability to use a maximum set number of retries

### DIFF
--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -43,7 +43,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	public readonly delay?: number | (() => number | Promise<number>);
 	public readonly errorHandler?: IErrorHandler;
 	public readonly logging?: boolean;
-	public readonly maxRetries?: number;
+	public readonly maxRetries: number;
 	public readonly tidProvider?: ITidProvider;
 	public readonly timeout?: number;
 
@@ -55,7 +55,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
 		this.delay = config?.delay;
-		this.maxRetries = config?.maxRetries;
+		this.maxRetries = config?.maxRetries ?? 1;
 		this.errorHandler = config?.errorHandler;
 		this.logging = config?.logging;
 		this.tidProvider = config?.tidProvider;

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -43,6 +43,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	public readonly delay?: number | (() => number | Promise<number>);
 	public readonly errorHandler?: IErrorHandler;
 	public readonly logging?: boolean;
+	public readonly maxRetries?: number;
 	public readonly tidProvider?: ITidProvider;
 	public readonly timeout?: number;
 
@@ -54,6 +55,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
 		this.delay = config?.delay;
+		this.maxRetries = config?.maxRetries;
 		this.errorHandler = config?.errorHandler;
 		this.logging = config?.logging;
 		this.tidProvider = config?.tidProvider;

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -43,6 +43,10 @@ export interface IRettiwtConfig {
 	 */
 	delay?: number | (() => number | Promise<number>);
 
-	/** The maximum number of retries to use. */
+	/**
+	 * The maximum number of retries to use.
+	 *
+	 * @remarks Recommended to use a value of 5 combined with a `delay` of 1000 to prevent error 404.
+	 */
 	maxRetries?: number;
 }

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -42,4 +42,7 @@ export interface IRettiwtConfig {
 	 * Can either be a number or a function that returns a number synchronously or asynchronously.
 	 */
 	delay?: number | (() => number | Promise<number>);
+
+	/** The maximum number of retries to use. */
+	maxRetries?: number;
 }


### PR DESCRIPTION
This can be configures using the parameter `maxRetries` while configuring `Rettiwt`, as follows:

```ts
const rettiwt = new Rettiwt({ apiKey: <API_KEY>, maxRetries: 5, delay: 1000 });
```

Setting `maxRetries` works best when used with a delay of 1000.