### PR TITLE
Added getter to get the current API key associated with the Rettiwt instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rettiwt-api",
-	"version": "6.0.5",
+	"version": "6.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rettiwt-api",
-			"version": "6.0.5",
+			"version": "6.0.6",
 			"license": "ISC",
 			"dependencies": {
 				"axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rettiwt-api",
-	"version": "6.0.5",
+	"version": "6.0.6",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"description": "An API for fetching data from TwitterAPI, without any rate limits!",

--- a/src/Rettiwt.ts
+++ b/src/Rettiwt.ts
@@ -70,6 +70,11 @@ export class Rettiwt {
 		this.user = new UserService(this._config);
 	}
 
+	/** Get the current API key associated with this instance. */
+	public get apiKey(): string | undefined {
+		return this._config.apiKey;
+	}
+
 	/** Set the API key for the current instance. */
 	public set apiKey(apiKey: string | undefined) {
 		this._config.apiKey = apiKey;


### PR DESCRIPTION
## 🔗 Related Issue

N/A

## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [X] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

Added a getter to `Rettiwt` to get the current API key associated with the instance.

The getter can be accessed as:
```ts
const rettiwt = new Rettiwt({ apiKey: <API_KEY> });

// Accessing the current API key
console.log(rettiwt.apiKey);
```

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.
