### PR TITLE
[README] Bump Node to 22.x (Node 20 no longer works)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CLI tool and an API for fetching data from Twitter for free!
 
 ## Prerequisites
 
-- NodeJS 20
+- NodeJS 22
 - A working Twitter account (optional)
 
 ## Installation


### PR DESCRIPTION
## 🔗 Related Issue

_None that I found_

## ❓ Type of Change
- [X] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

I hit build/runtime failures on Node 20 in both local and CI environments - it seems dependencies now expect Node 22, and upgrading removes the breakage. Node 22 is the current Active LTS, so this aligns us with supported tooling going forward.

It seems `package.json` already references 22 so I just tweaked the README for new users.

## 📝 Checklist

- [N/A] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [N/A] Code follows project conventions and ESLint rules.
- [N/A] No sensitive data or credentials are included.
