### PR TITLE
A stable query method for username has been added to details().

### DIFF
--- a/src/models/data/Tweet.ts
+++ b/src/models/data/Tweet.ts
@@ -53,7 +53,9 @@ export class Tweet implements ITweet {
 		this.entities = new TweetEntities(tweet.legacy.entities);
 		this.media = tweet.legacy.extended_entities?.media?.map((media) => new TweetMedia(media));
 		this.quoted = this._getQuotedTweet(tweet);
-		this.fullText =  tweet.note_tweet?.note_tweet_results?.result?.text ? tweet.note_tweet.note_tweet_results.result.text : tweet.legacy.full_text;
+		this.fullText = tweet.note_tweet?.note_tweet_results?.result?.text
+			? tweet.note_tweet.note_tweet_results.result.text
+			: tweet.legacy.full_text;
 		this.replyTo = tweet.legacy.in_reply_to_status_id_str;
 		this.lang = tweet.legacy.lang;
 		this.quoteCount = tweet.legacy.quote_count;

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -228,8 +228,8 @@ export class UserService extends FetcherService {
 	 * // Creating a new Rettiwt instance using the given 'API_KEY'
 	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
 	 *
-	 * // Fetching the details of the User with username 'user1'
-	 * rettiwt.user.details('user1')
+	 * // Fetching the details of the User with username 'user1' or '@user1'
+	 * rettiwt.user.details('user1') // or @user1
 	 * .then(res => {
 	 * 	console.log(res);
 	 * })

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -306,6 +306,9 @@ export class UserService extends FetcherService {
 			// If username is given
 			if (id && isNaN(Number(id))) {
 				resource = ResourceType.USER_DETAILS_BY_USERNAME;
+				if (id?.startsWith("@")) {
+					id = id.slice(1);
+				}
 			}
 			// If id is given (or not, for self details)
 			else {

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -306,7 +306,7 @@ export class UserService extends FetcherService {
 			// If username is given
 			if (id && isNaN(Number(id))) {
 				resource = ResourceType.USER_DETAILS_BY_USERNAME;
-				if (id?.startsWith("@")) {
+				if (id?.startsWith('@')) {
 					id = id.slice(1);
 				}
 			}


### PR DESCRIPTION
A stable query method for username has been added to details().

## 🔗 Related Issue

Open #786 


## ❓ Type of Change

<!-- Select all that apply -->

- [ ] 📖 Documentation (docs, README, or comments)
- [x] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

As I mentioned in the issue, when a Twitter user's username is purely numeric, details() treats it as an id for querying, which is unreasonable.

Therefore, I proposed an idea: if the `details()` function includes the `@` symbol as a parameter, it can be assumed that the query explicitly points to the `username`. This approach neither affects existing functionality nor fails to fix the bug I described.

## 📝 Checklist

- [x] Issue/discussion linked above.
- [ ] Documentation updated (if needed).
- [x] Code follows project conventions and ESLint rules.
- [x] No sensitive data or credentials are included.

@Rishikant181 
