### PR TITLE
Impression count fields are now optional in Tweet

### DIFF
--- a/src/models/data/Tweet.ts
+++ b/src/models/data/Tweet.ts
@@ -22,24 +22,24 @@ export class Tweet implements ITweet {
 	/** The raw tweet details. */
 	private readonly _raw: IRawTweet;
 
-	public bookmarkCount: number;
+	public bookmarkCount?: number;
 	public conversationId: string;
 	public createdAt: string;
 	public entities: TweetEntities;
 	public fullText: string;
 	public id: string;
 	public lang: string;
-	public likeCount: number;
+	public likeCount?: number;
 	public media?: TweetMedia[];
-	public quoteCount: number;
+	public quoteCount?: number;
 	public quoted?: Tweet;
-	public replyCount: number;
+	public replyCount?: number;
 	public replyTo?: string;
-	public retweetCount: number;
+	public retweetCount?: number;
 	public retweetedTweet?: Tweet;
 	public tweetBy: User;
 	public url: string;
-	public viewCount: number;
+	public viewCount?: number;
 
 	/**
 	 * @param tweet - The raw tweet details.
@@ -62,7 +62,7 @@ export class Tweet implements ITweet {
 		this.replyCount = tweet.legacy.reply_count;
 		this.retweetCount = tweet.legacy.retweet_count;
 		this.likeCount = tweet.legacy.favorite_count;
-		this.viewCount = tweet.views?.count ? parseInt(tweet.views.count) : 0;
+		this.viewCount = tweet.views?.count ? parseInt(tweet.views.count) : undefined;
 		this.bookmarkCount = tweet.legacy.bookmark_count;
 		this.retweetedTweet = this._getRetweetedTweet(tweet);
 		this.url = `https://x.com/${this.tweetBy.userName}/status/${this.id}`;

--- a/src/types/data/Tweet.ts
+++ b/src/types/data/Tweet.ts
@@ -9,7 +9,7 @@ import { IUser } from './User';
  */
 export interface ITweet {
 	/** The number of bookmarks of a tweet. */
-	bookmarkCount: number;
+	bookmarkCount?: number;
 
 	/** The ID of tweet which started the current conversation. */
 	conversationId: string;
@@ -30,25 +30,25 @@ export interface ITweet {
 	lang: string;
 
 	/** The number of likes of the tweet. */
-	likeCount: number;
+	likeCount?: number;
 
 	/** The urls of the media contents of the tweet (if any). */
 	media?: ITweetMedia[];
 
 	/** The number of quotes of the tweet. */
-	quoteCount: number;
+	quoteCount?: number;
 
 	/** The tweet which is quoted in the tweet. */
 	quoted?: ITweet;
 
 	/** The number of replies to the tweet. */
-	replyCount: number;
+	replyCount?: number;
 
 	/** The rest id of the tweet to which the tweet is a reply. */
 	replyTo?: string;
 
 	/** The number of retweets of the tweet. */
-	retweetCount: number;
+	retweetCount?: number;
 
 	/** The tweet which is retweeted in this tweet (if any). */
 	retweetedTweet?: ITweet;
@@ -60,7 +60,7 @@ export interface ITweet {
 	url: string;
 
 	/** The number of views of a tweet. */
-	viewCount: number;
+	viewCount?: number;
 }
 
 /**

--- a/src/types/raw/base/Tweet.ts
+++ b/src/types/raw/base/Tweet.ts
@@ -17,7 +17,7 @@ export interface ITweet {
 	edit_control: ITweetEditControl;
 	edit_perspective: ITweetEditPerspective;
 	is_translatable: boolean;
-	views: ITweetViews;
+	views?: ITweetViews;
 	source: string;
 	quoted_status_result: IDataResult<ITweet | ILimitedVisibilityTweet>;
 	note_tweet: ITweetNote;
@@ -78,14 +78,14 @@ export interface ITweetNoteMedia {
 }
 
 export interface ITweetLegacy {
-	bookmark_count: number;
+	bookmark_count?: number;
 	bookmarked: boolean;
 	created_at: string;
 	conversation_id_str: string;
 	display_text_range: number[];
 	entities: IEntities;
 	extended_entities: IExtendedEntities;
-	favorite_count: number;
+	favorite_count?: number;
 	favorited: boolean;
 	full_text: string;
 	in_reply_to_status_id_str: string;
@@ -93,10 +93,10 @@ export interface ITweetLegacy {
 	lang: string;
 	possibly_sensitive: boolean;
 	possibly_sensitive_editable: boolean;
-	quote_count: number;
+	quote_count?: number;
 	quoted_status_id_str: string;
-	reply_count: number;
-	retweet_count: number;
+	reply_count?: number;
+	retweet_count?: number;
 	retweeted: boolean;
 	user_id_str: string;
 	id_str: string;


### PR DESCRIPTION
## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [X] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

For tweets which have hidden impressions (likes, views, replies, retweets, etc), the corresponding field is absent from the raw response. As such, the corresponding fields in the `Tweet` type have been made optional for consistency and undesired results.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.
