### PR TITLE
Made isFollowed and isFollowing field optional

### DIFF
--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -20,8 +20,8 @@ export class User implements IUser {
 	public followingsCount: number;
 	public fullName: string;
 	public id: string;
-	public isFollowed: boolean;
-	public isFollowing: boolean;
+	public isFollowed?: boolean;
+	public isFollowing?: boolean;
 	public isVerified: boolean;
 	public likeCount: number;
 	public location?: string;
@@ -41,8 +41,8 @@ export class User implements IUser {
 		this.fullName = user.legacy.name;
 		this.createdAt = new Date(user.legacy.created_at).toISOString();
 		this.description = user.legacy.description.length ? user.legacy.description : undefined;
-		this.isFollowed = user.legacy.following ?? false;
-		this.isFollowing = user.legacy.followed_by ?? false;
+		this.isFollowed = user.legacy.following;
+		this.isFollowing = user.legacy.followed_by;
 		this.isVerified = user.is_blue_verified;
 		this.likeCount = user.legacy.favourites_count;
 		this.followersCount = user.legacy.followers_count;

--- a/src/types/data/User.ts
+++ b/src/types/data/User.ts
@@ -22,11 +22,11 @@ export interface IUser {
 	/** The rest id of the user. */
 	id: string;
 
-	/** Whether the user is being followed by the logged-in user. */
-	isFollowed: boolean;
+	/** Whether the user is being followed by the logged-in user. Available only when logged in. */
+	isFollowed?: boolean;
 
-	/** Whether the user is following the logged-in user. */
-	isFollowing: boolean;
+	/** Whether the user is following the logged-in user. Available only when logged in. */
+	isFollowing?: boolean;
 
 	/** Whether the account is verified or not. */
 	isVerified: boolean;


### PR DESCRIPTION
## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [X] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

When using guest authentication, the follow status of a target user is absent from the raw response. As such, the corresponding fields (`isFollowed` and `isFollowing`) in the `User` type have been made optional for consistency and preventing undesired results.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.