### PR TITLE
✨ Add quoters support to retweeters() method with CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ So far, the following operations are supported:
 - [Posting a new tweet](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#post)
 - [Getting the list of replies to a tweet](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#replies)
 - [Retweeting a tweet](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#retweet)
-- [Getting the list of users who retweeted a given tweet by the logged-in user](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#retweeters)
+- [Getting the list of users who retweeted/quoted a given tweet (supports quotersOnly and includeQuoters options)](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#retweeters)
 - [Scheduling a new tweet](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#schedule)
 - [Searching for the list of tweets that match a given filter](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#search)
 - [Streaming filtered tweets in pseudo-realtime](https://rishikant181.github.io/Rettiwt-API/classes/TweetService.html#stream)

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -155,18 +155,34 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 	// Retweeters
 	tweet
 		.command('retweeters')
-		.description('Fetch the list of users who retweeted the given tweets')
+		.description('Fetch the list of users who retweeted and/or quoted the given tweet')
 		.argument('<id>', 'The id of the tweet')
-		.argument('[count]', 'The number of retweeters to fetch')
-		.argument('[cursor]', 'The cursor to the batch of retweeters to fetch')
-		.action(async (id: string, count?: string, cursor?: string) => {
-			try {
-				const users = await rettiwt.tweet.retweeters(id, count ? parseInt(count) : undefined, cursor);
-				output(users);
-			} catch (error) {
-				output(error);
-			}
-		});
+		.argument('[count]', 'The number of users to fetch')
+		.argument('[cursor]', 'The cursor to the batch of users to fetch')
+		.option('--quoters-only', 'Fetch only users who quoted the tweet (instead of retweeters)')
+		.option('--include-quoters', 'Fetch both retweeters and quoters together')
+		.action(
+			async (
+				id: string,
+				count?: string,
+				cursor?: string,
+				options?: { quotersOnly?: boolean; includeQuoters?: boolean },
+			) => {
+				try {
+					const users = await rettiwt.tweet.retweeters(
+						id,
+						count ? parseInt(count) : undefined,
+						cursor,
+						options
+							? { quotersOnly: options.quotersOnly, includeQuoters: options.includeQuoters }
+							: undefined,
+					);
+					output(users);
+				} catch (error) {
+					output(error);
+				}
+			},
+		);
 
 	// Schedule
 	tweet

--- a/src/commands/Tweet.ts
+++ b/src/commands/Tweet.ts
@@ -155,13 +155,20 @@ function createTweetCommand(rettiwt: Rettiwt): Command {
 	// Retweeters
 	tweet
 		.command('retweeters')
-		.description('Fetch the list of users who retweeted the given tweets')
+		.description('Fetch the list of users who retweeted and/or quoted the given tweet')
 		.argument('<id>', 'The id of the tweet')
-		.argument('[count]', 'The number of retweeters to fetch')
-		.argument('[cursor]', 'The cursor to the batch of retweeters to fetch')
-		.action(async (id: string, count?: string, cursor?: string) => {
+		.argument('[count]', 'The number of users to fetch')
+		.argument('[cursor]', 'The cursor to the batch of users to fetch')
+		.option('--quoters-only', 'Fetch only users who quoted the tweet (instead of retweeters)')
+		.option('--include-quoters', 'Fetch both retweeters and quoters together')
+		.action(async (id: string, count?: string, cursor?: string, options?: { quotersOnly?: boolean; includeQuoters?: boolean }) => {
 			try {
-				const users = await rettiwt.tweet.retweeters(id, count ? parseInt(count) : undefined, cursor);
+				const users = await rettiwt.tweet.retweeters(
+					id,
+					count ? parseInt(count) : undefined,
+					cursor,
+					options ? { quotersOnly: options.quotersOnly, includeQuoters: options.includeQuoters } : undefined,
+				);
 				output(users);
 			} catch (error) {
 				output(error);

--- a/src/models/data/CursoredData.ts
+++ b/src/models/data/CursoredData.ts
@@ -47,6 +47,22 @@ export class CursoredData<T extends Notification | Tweet | User | List> implemen
 	}
 
 	/**
+	 * Creates a CursoredData instance from a pre-built list and cursor.
+	 *
+	 * @param list - The list of items.
+	 * @param next - The cursor for the next page.
+	 * @returns A new CursoredData instance.
+	 *
+	 * @internal
+	 */
+	public static fromList<T extends Notification | Tweet | User | List>(list: T[], next?: string): CursoredData<T> {
+		const instance = Object.create(CursoredData.prototype) as CursoredData<T>;
+		instance.list = list;
+		instance.next = next ?? '';
+		return instance;
+	}
+
+	/**
 	 * @returns A serializable JSON representation of `this` object.
 	 */
 	public toJSON(): ICursoredData<T> {

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -8,7 +8,7 @@ import { Tweet } from '../../models/data/Tweet';
 import { User } from '../../models/data/User';
 
 import { RettiwtConfig } from '../../models/RettiwtConfig';
-import { ITweetFilter } from '../../types/args/FetchArgs';
+import { IRetweetersOptions, ITweetFilter } from '../../types/args/FetchArgs';
 import { INewTweet } from '../../types/args/PostArgs';
 import { IMediaInitializeUploadResponse } from '../../types/raw/media/InitalizeUpload';
 
@@ -44,6 +44,125 @@ export class TweetService extends FetcherService {
 	 */
 	public constructor(config: RettiwtConfig) {
 		super(config);
+	}
+
+	/**
+	 * Decode a combined cursor into retweeters and quoters cursors.
+	 *
+	 * @param cursor - The combined cursor string.
+	 * @returns Object with separate cursors for retweeters and quoters.
+	 *
+	 * @internal
+	 */
+	private _decodeCombinedCursor(cursor?: string): { retweeters?: string; quoters?: string } {
+		if (!cursor) {
+			return {};
+		}
+
+		// Check if it's a combined cursor
+		if (!cursor.includes('|')) {
+			return { retweeters: cursor };
+		}
+
+		const parts = cursor.split('|');
+		const retweetersPart = parts[0] || '';
+		const quotersPart = parts[1] || '';
+
+		return {
+			retweeters: retweetersPart.startsWith('r:') ? retweetersPart.slice(2) || undefined : undefined,
+			quoters: quotersPart.startsWith('q:') ? quotersPart.slice(2) || undefined : undefined,
+		};
+	}
+
+	/**
+	 * Encode retweeters and quoters cursors into a combined cursor.
+	 *
+	 * @param retweetersCursor - The cursor for retweeters.
+	 * @param quotersCursor - The cursor for quoters.
+	 * @returns The combined cursor string, or undefined if both are empty.
+	 *
+	 * @internal
+	 */
+	private _encodeCombinedCursor(retweetersCursor?: string, quotersCursor?: string): string | undefined {
+		// If both cursors are empty, return undefined
+		if (!retweetersCursor && !quotersCursor) {
+			return undefined;
+		}
+
+		return `r:${retweetersCursor || ''}|q:${quotersCursor || ''}`;
+	}
+
+	/**
+	 * Get the list of users who quoted a tweet using search.
+	 *
+	 * @param id - The ID of the target tweet.
+	 * @param count - The number of quoters to fetch.
+	 * @param cursor - The cursor to the batch of quoters to fetch.
+	 *
+	 * @returns The list of users who quoted the given tweet.
+	 *
+	 * @internal
+	 */
+	private async _getQuoters(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
+		// Search for tweets that quote the target tweet
+		const quotingTweets = await this.search({ quoted: id }, count, cursor);
+
+		// Extract unique users from the quoting tweets
+		const usersMap = new Map<string, User>();
+		for (const tweet of quotingTweets.list) {
+			if (tweet.tweetBy && !usersMap.has(tweet.tweetBy.id)) {
+				usersMap.set(tweet.tweetBy.id, tweet.tweetBy);
+			}
+		}
+
+		// Create CursoredData with users
+		const users = Array.from(usersMap.values());
+
+		return CursoredData.fromList<User>(users, quotingTweets.next);
+	}
+
+	/**
+	 * Get both retweeters and quoters of a tweet.
+	 *
+	 * @param id - The ID of the target tweet.
+	 * @param count - The number of users to fetch per source.
+	 * @param cursor - The combined cursor in format `r:RETWEETERS_CURSOR|q:QUOTERS_CURSOR`.
+	 *
+	 * @returns The combined list of users who retweeted or quoted the given tweet.
+	 *
+	 * @internal
+	 */
+	private async _getRetweetersAndQuoters(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
+		// Decode combined cursor
+		const decodedCursor = this._decodeCombinedCursor(cursor);
+
+		// Fetch both in parallel
+		const [retweetersResult, quotersResult] = await Promise.all([
+			this.retweeters(id, count, decodedCursor.retweeters),
+			this._getQuoters(id, count, decodedCursor.quoters),
+		]);
+
+		// Merge users and remove duplicates
+		const usersMap = new Map<string, User>();
+
+		for (const user of retweetersResult.list) {
+			if (!usersMap.has(user.id)) {
+				usersMap.set(user.id, user);
+			}
+		}
+
+		for (const user of quotersResult.list) {
+			if (!usersMap.has(user.id)) {
+				usersMap.set(user.id, user);
+			}
+		}
+
+		const uniqueUsers = Array.from(usersMap.values()).slice(0, count);
+
+		// Encode combined cursor for next page
+		const nextCursor = this._encodeCombinedCursor(retweetersResult.next, quotersResult.next);
+
+		return CursoredData.fromList<User>(uniqueUsers, nextCursor);
 	}
 
 	/**
@@ -446,16 +565,18 @@ export class TweetService extends FetcherService {
 	}
 
 	/**
-	 * Get the list of users who retweeted a tweet.
+	 * Get the list of users who retweeted and/or quoted a tweet.
 	 *
 	 * @param id - The ID of the target tweet.
-	 * @param count - The number of retweeters to fetch, must be \<= 100.
-	 * @param cursor - The cursor to the batch of retweeters to fetch.
+	 * @param count - The number of users to fetch, must be \<= 100.
+	 * @param cursor - The cursor to the batch of users to fetch.
+	 * @param options - Options to include quoters or fetch only quoters.
 	 *
-	 * @returns The list of users who retweeted the given tweet.
+	 * @returns The list of users who retweeted/quoted the given tweet.
 	 *
 	 * @example
 	 *
+	 * #### Fetching retweeters (default behavior)
 	 * ```ts
 	 * import { Rettiwt } from 'rettiwt-api';
 	 *
@@ -471,8 +592,67 @@ export class TweetService extends FetcherService {
 	 * 	console.log(err);
 	 * });
 	 * ```
+	 *
+	 * @example
+	 *
+	 * #### Fetching only quoters
+	 * ```ts
+	 * import { Rettiwt } from 'rettiwt-api';
+	 *
+	 * // Creating a new Rettiwt instance using the given 'API_KEY'
+	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
+	 *
+	 * // Fetching users who quoted the Tweet with id '1234567890'
+	 * rettiwt.tweet.retweeters('1234567890', undefined, undefined, { quotersOnly: true })
+	 * .then(res => {
+	 * 	console.log(res);
+	 * })
+	 * .catch(err => {
+	 * 	console.log(err);
+	 * });
+	 * ```
+	 *
+	 * @example
+	 *
+	 * #### Fetching both retweeters and quoters
+	 * ```ts
+	 * import { Rettiwt } from 'rettiwt-api';
+	 *
+	 * // Creating a new Rettiwt instance using the given 'API_KEY'
+	 * const rettiwt = new Rettiwt({ apiKey: API_KEY });
+	 *
+	 * // Fetching both retweeters and quoters of the Tweet with id '1234567890'
+	 * rettiwt.tweet.retweeters('1234567890', undefined, undefined, { includeQuoters: true })
+	 * .then(res => {
+	 * 	console.log(res);
+	 * })
+	 * .catch(err => {
+	 * 	console.log(err);
+	 * });
+	 * ```
 	 */
-	public async retweeters(id: string, count?: number, cursor?: string): Promise<CursoredData<User>> {
+	public async retweeters(
+		id: string,
+		count?: number,
+		cursor?: string,
+		options?: IRetweetersOptions,
+	): Promise<CursoredData<User>> {
+		// Validate options
+		if (options?.quotersOnly && options?.includeQuoters) {
+			throw new Error('Cannot use both quotersOnly and includeQuoters at the same time');
+		}
+
+		// Mode 1: Only quoters
+		if (options?.quotersOnly) {
+			return this._getQuoters(id, count, cursor);
+		}
+
+		// Mode 2: Both retweeters and quoters
+		if (options?.includeQuoters) {
+			return this._getRetweetersAndQuoters(id, count, cursor);
+		}
+
+		// Mode 3: Only retweeters (default)
 		const resource = ResourceType.TWEET_RETWEETERS;
 
 		// Fetching raw list of retweeters

--- a/src/types/args/FetchArgs.ts
+++ b/src/types/args/FetchArgs.ts
@@ -231,3 +231,29 @@ export interface ITweetFilter {
 	/** Whether to fetch top tweets or not. */
 	top?: boolean;
 }
+
+/**
+ * Options for fetching retweeters and/or quoters of a tweet.
+ *
+ * @public
+ */
+export interface IRetweetersOptions {
+	/**
+	 * If true, fetches only users who quoted the tweet (instead of retweeters).
+	 *
+	 * @remarks
+	 * - Cannot be used together with `includeQuoters`.
+	 * - When true, uses search endpoint to find quote tweets and extracts users.
+	 */
+	quotersOnly?: boolean;
+
+	/**
+	 * If true, fetches both retweeters and quoters together.
+	 *
+	 * @remarks
+	 * - Cannot be used together with `quotersOnly`.
+	 * - Makes parallel requests to both endpoints and merges results.
+	 * - Cursor format becomes `r:<retweeters_cursor>|q:<quoters_cursor>`.
+	 */
+	includeQuoters?: boolean;
+}


### PR DESCRIPTION
## feat: extend retweeters() to fetch users who quoted a tweet

- Add `quotersOnly` option to fetch only quote tweet authors
- Add `includeQuoters` option to fetch both retweeters and quoters
- Add CLI flags: --quoters-only, --include-quoters
- Add IRetweetersOptions interface
- Add CursoredData.fromList() static factory method
- Implement combined cursor format for pagination (r:|q:)
- Handle duplicate users when combining results

📦 Modified files:
  - src/services/public/TweetService.ts
  - src/types/args/FetchArgs.ts
  - src/models/data/CursoredData.ts
  - src/commands/Tweet.ts
  - README.md

## 🔗 Related Issue

Closes #805

## ❓ Type of Change

- [x] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [x] 👌 Enhancement (improvement to existing functionality)
- [x] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

This PR extends the existing `retweeters()` method to support fetching users who quoted a specific tweet (Quote Tweets).

### ✨ New Features

**API Usage:**
```typescript
// Fetch only users who quoted the tweet
const quoters = await rettiwt.tweet.retweeters('1234567890', 20, undefined, {
  quotersOnly: true
});

// Fetch both retweeters and quoters combined
const both = await rettiwt.tweet.retweeters('1234567890', 20, undefined, {
  includeQuoters: true
});
```

**CLI Usage:**
```bash
# Fetch only quoters
rettiwt -k API_KEY tweet retweeters 1234567890 --quoters-only

# Fetch both retweeters and quoters
rettiwt -k API_KEY tweet retweeters 1234567890 --include-quoters
```

### 🔧 Technical Details

- Uses the existing `search({ quoted: id })` endpoint to find quote tweets
- Combined cursor format (`r:CURSOR|q:CURSOR`) maintains pagination state for both sources
- Parallel requests with `Promise.all()` for `includeQuoters` mode
- Duplicate users are filtered using a Map
- Results respect the `count` parameter even in combined mode
- Backward compatible: default behavior remains unchanged

### ⚠️ Notes

- `includeQuoters` mode makes 2 parallel API calls, which may increase rate limit consumption
- Using both `quotersOnly` and `includeQuoters` together throws an error

## 📝 Checklist

- [x] Issue/discussion linked above.
- [x] Documentation updated (if needed).
- [x] Code follows project conventions and ESLint rules.
- [x] No sensitive data or credentials are included.
