### PR TITLE
Added error handling for errors with HTTP status code 200 (#796)

### DIFF
--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -1,4 +1,4 @@
-import axios, { isAxiosError } from 'axios';
+import axios, { AxiosError, isAxiosError } from 'axios';
 import { Cookie } from 'cookiejar';
 import { JSDOM } from 'jsdom';
 import { ClientTransaction } from 'x-client-transaction-id';
@@ -11,11 +11,13 @@ import { ResourceType } from '../../enums/Resource';
 import { FetchArgs } from '../../models/args/FetchArgs';
 import { PostArgs } from '../../models/args/PostArgs';
 import { AuthCredential } from '../../models/auth/AuthCredential';
+import { TwitterError } from '../../models/errors/TwitterError';
 import { RettiwtConfig } from '../../models/RettiwtConfig';
 import { IFetchArgs } from '../../types/args/FetchArgs';
 import { IPostArgs } from '../../types/args/PostArgs';
 import { ITransactionHeader } from '../../types/auth/TransactionHeader';
 import { IErrorHandler } from '../../types/ErrorHandler';
+import { IErrorData } from '../../types/raw/base/Error';
 
 import { AuthService } from '../internal/AuthService';
 import { ErrorService } from '../internal/ErrorService';
@@ -322,8 +324,27 @@ export class FetcherService {
 				// Introducing a delay
 				await this._wait();
 
+				// Getting the response body
+				const responseData = (await axios<T>(config)).data;
+
+				// Check for Twitter API errors in response body
+				// Type guard to check if response contains errors
+				const potentialErrorResponse = responseData as unknown as Partial<IErrorData>;
+				if (potentialErrorResponse.errors && Array.isArray(potentialErrorResponse.errors)) {
+					// Throw TwitterError using existing error class
+					const axiosError = {
+						response: {
+							data: { errors: potentialErrorResponse.errors },
+							status: 200,
+						},
+						message: potentialErrorResponse.errors[0]?.message ?? 'Twitter API Error',
+						status: 200,
+					} as AxiosError<IErrorData>;
+					throw new TwitterError(axiosError);
+				}
+
 				// Returning the reponse body
-				return (await axios<T>(config)).data;
+				return responseData;
 			} catch (err) {
 				// If it's an error 404, retry
 				if (isAxiosError(err) && err.status === 404) {


### PR DESCRIPTION
## 🔗 Related Issue

Closes #749

## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [X] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

When Twitter returns errors that carry an HTTP status code of 200, earlier, Rettiwt failed to catch and handle them. With this patch, Rettiwt now catches the error appropriately and delegates error handling to the configured error handler.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.

<!--
If you need help, mention @Rishikant181 or ask in the discussions.
-->
