### PR TITLE
Fixed an issue where profile image was missing from deserialized user

### DIFF
--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -51,7 +51,7 @@ export class User implements IUser {
 		this.location = user.location?.location ?? user.legacy.location ?? undefined;
 		this.pinnedTweet = user.legacy.pinned_tweet_ids_str[0];
 		this.profileBanner = user.legacy.profile_banner_url;
-		this.profileImage = user.legacy.profile_image_url_https;
+		this.profileImage = user.avatar?.image_url ?? user.legacy.profile_image_url_https ?? '';
 	}
 
 	/** The raw user details. */

--- a/src/types/raw/base/User.ts
+++ b/src/types/raw/base/User.ts
@@ -12,6 +12,7 @@ export interface IUser {
 	id: string;
 	rest_id: string;
 	core?: IUserCore;
+	avatar?: IUserAvatar;
 	affiliates_highlighted_label: IAffiliatesHighlightedLabel;
 	has_graduated_access: boolean;
 	is_blue_verified: boolean;
@@ -34,6 +35,10 @@ export interface IUserCore {
 	created_at: string;
 	name: string;
 	screen_name: string;
+}
+
+export interface IUserAvatar {
+	image_url: string;
 }
 
 export interface IAffiliatesHighlightedLabel {
@@ -114,7 +119,7 @@ export interface IUserLegacy {
 	pinned_tweet_ids_str: string[];
 	possibly_sensitive: boolean;
 	profile_banner_url: string;
-	profile_image_url_https: string;
+	profile_image_url_https?: string;
 	profile_interstitial_type: string;
 	statuses_count: number;
 	translator_type: string;


### PR DESCRIPTION
## 🔗 Related Issue

Closes #817

## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [X] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

The profile image was missing because of the profile image URL being moved to a nested `avatar` field in the user data returned from some updated endpoints. This PR fixes it by first searching for the image in the new location, and if not found, falls back to the old one.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.
