### PR TITLE
Add media `id` to Tweet media model & types

### DIFF
--- a/src/models/data/Tweet.ts
+++ b/src/models/data/Tweet.ts
@@ -272,7 +272,7 @@ export class Tweet implements ITweet {
  *
  * @public
  */
-export class TweetEntities {
+export class TweetEntities implements ITweetEntities {
 	/** The list of hashtags mentioned in the tweet. */
 	public hashtags: string[] = [];
 
@@ -325,7 +325,7 @@ export class TweetEntities {
  *
  * @public
  */
-export class TweetMedia {
+export class TweetMedia implements ITweetMedia {
 	/** The thumbnail URL for the video content of the tweet. */
 	public thumbnailUrl?: string;
 
@@ -335,10 +335,15 @@ export class TweetMedia {
 	/** The direct URL to the media. */
 	public url = '';
 
+	/** The ID of the media. */
+    public id: string;
+
 	/**
 	 * @param media - The raw media details.
 	 */
 	public constructor(media: IRawExtendedMedia) {
+        this.id = media.id_str;
+
 		// If the media is a photo
 		if (media.type == RawMediaType.PHOTO) {
 			this.type = MediaType.PHOTO;
@@ -374,6 +379,7 @@ export class TweetMedia {
 	 */
 	public toJSON(): ITweetMedia {
 		return {
+            id: this.id,
 			thumbnailUrl: this.thumbnailUrl,
 			type: this.type,
 			url: this.url,

--- a/src/types/data/Tweet.ts
+++ b/src/types/data/Tweet.ts
@@ -85,6 +85,9 @@ export interface ITweetEntities {
  * @public
  */
 export interface ITweetMedia {
+	/** The ID of the media. */
+	id: string;
+	
 	/** The thumbnail URL for the video content of the tweet. */
 	thumbnailUrl?: string;
 


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Reference any related issue or discussion, e.g. "Closes #123" -->
N/A

## ❓ Type of Change

<!-- Select all that apply -->

- [ ] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [x] 👌 Enhancement (improvement to existing functionality)
- [x] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

This PR adds a stable `id` field to tweet media objects and aligns runtime models with the exported TypeScript types.

Changes included:
- Add `id: string` to `ITweetMedia`.
- Update `TweetMedia` to implement `ITweetMedia`.
- Populate `TweetMedia.id` from the raw API payload (`IRawExtendedMedia.id_str`).
- Include `id` in `TweetMedia.toJSON()` output.
- Update `TweetEntities` to implement `ITweetEntities` for improved typing consistency.

Motivation:
Some consumers need a media identifier for operations like deduplication, caching, UI keying, and reliably referencing a specific media item. Previously, the media model exposed fields like `type`, `url`, and `thumbnailUrl`, but not a stable media `id`.

## 📝 Checklist

- [ ] Issue/discussion linked above.
- [ ] Documentation updated (if needed).
- [x] Code follows project conventions and ESLint rules.
- [x] No sensitive data or credentials are included.

<!--
If you need help, mention @Rishikant181 or ask in the discussions.
-->