### PR TITLE
chore: playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
 			"name": "rettiwt-api",
 			"version": "6.2.0",
 			"license": "ISC",
-			"workspaces": [
-				"playground",
-				"src"
-			],
 			"dependencies": {
 				"axios": "^1.8.4",
 				"chalk": "^5.4.1",
@@ -1695,18 +1691,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "17.2.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
-			"integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -4122,31 +4106,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/rettiwt-api": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/rettiwt-api/-/rettiwt-api-6.0.5.tgz",
-			"integrity": "sha512-YqFu6TXl58hCo+k8TGLca5/NM6nJJKCRYRhEgH67YtuPVrA6aFA71k+S7hVE+9rmzOKCBAEbFN/h1A/j2WazqA==",
-			"license": "ISC",
-			"dependencies": {
-				"axios": "^1.8.4",
-				"chalk": "^5.4.1",
-				"commander": "^11.1.0",
-				"cookiejar": "^2.1.4",
-				"https-proxy-agent": "^7.0.6",
-				"node-html-parser": "^7.0.1",
-				"x-client-transaction-id-glacier": "^1.0.0"
-			},
-			"bin": {
-				"rettiwt": "dist/cli.js"
-			},
-			"engines": {
-				"node": "^22.13.1"
-			}
-		},
-		"node_modules/rettiwt-playground": {
-			"resolved": "playground",
-			"link": true
-		},
 		"node_modules/reusify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5041,15 +5000,6 @@
 				"linkedom": "^0.18.9"
 			}
 		},
-		"node_modules/x-client-transaction-id-glacier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/x-client-transaction-id-glacier/-/x-client-transaction-id-glacier-1.0.0.tgz",
-			"integrity": "sha512-LmRJHgLTkksatezztTO+52SpGcwYLf90O2r2t4L9leAlhM5lOv/03c5izupwswmQAFA4Uk0str4qEV34KhBUAw==",
-			"license": "MIT",
-			"dependencies": {
-				"linkedom": "^0.18.9"
-			}
-		},
 		"node_modules/xml-name-validator": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -5094,9 +5044,10 @@
 		"playground": {
 			"name": "rettiwt-playground",
 			"version": "1.0.0",
+			"extraneous": true,
 			"dependencies": {
 				"dotenv": "^17.2.0",
-				"rettiwt-api": "workspace"
+				"rettiwt-api": "file:../"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -55,9 +55,5 @@
 		"jsdom": "^27.2.0",
 		"node-html-parser": "^7.0.1",
 		"x-client-transaction-id": "^0.1.9"
-	},
-	"workspaces": [
-		"playground",
-		"src"
-	]
+	}
 }

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -1,1 +1,1 @@
-ACCESS_TOKEN=""
+API_KEY=""

--- a/playground/README.md
+++ b/playground/README.md
@@ -23,7 +23,7 @@ This playground is intended for developers to test and experiment with features 
 2. **Environment Variables**
    Create a `.env` file in the `playground` directory with your API credentials:
     ```env
-    ACCESS_TOKEN=your_access_token_here
+    API_KEY=your_api_key_here
     ```
 
 ### Usage

--- a/playground/index.js
+++ b/playground/index.js
@@ -1,7 +1,7 @@
 import { Rettiwt } from 'rettiwt-api';
 import 'dotenv/config';
 
-const rettiwt = new Rettiwt({ apiKey: process.env.ACCESS_TOKEN });
+const rettiwt = new Rettiwt({ apiKey: process.env.API_KEY });
 
 async function userDetails() {
 	try {

--- a/playground/package.json
+++ b/playground/package.json
@@ -10,6 +10,6 @@
 	},
 	"dependencies": {
 		"dotenv": "^17.2.0",
-		"rettiwt-api": "workspace"
+		"rettiwt-api": "file:../"
 	}
 }


### PR DESCRIPTION
## 🔗 Related Issue

N/A

## ❓ Type of Change

<!-- Select all that apply -->

- [ ] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [x] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [x] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

This pull request updates the playground environment variable naming convention and makes related adjustments to improve clarity and consistency. It also modifies workspace configuration and dependency references.

**Environment variable renaming and usage updates:**

* Changed the environment variable from `ACCESS_TOKEN` to `API_KEY` in `.env.example`, `README.md`, and in the code that instantiates `Rettiwt`, ensuring consistent naming throughout the playground. [[1]](diffhunk://#diff-a8755aa4f606b7ebbfe362f1b5e05d9aa4a9b3384513ff61f1b7b72d83df86b0L1-R1) [[2]](diffhunk://#diff-65586928a2d645d043f4979198e41062990f2fb97fe7b2d4191f7dcebb66a11aL26-R26) [[3]](diffhunk://#diff-c54605dd5457947db1b8a2ca040bd41c28e70c8770b5e11494236ed36071d430L4-R4)

**Project and dependency configuration:**

* Updated the `rettiwt-api` dependency reference in `playground/package.json` to use a local file path instead of a workspace reference.
* Removed the `workspaces` field from the root `package.json`, simplifying the project structure.

## 📝 Checklist

- [ ] Issue/discussion linked above.
- [x] Documentation updated (if needed).
- [x] Code follows project conventions and ESLint rules.
- [x] No sensitive data or credentials are included.

