### PR TITLE
fix:local proxy request error

### DIFF
--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -36,7 +36,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	private _apiKey?: string;
 	private _headers: { [key: string]: string };
 	private _httpsAgent: Agent;
-	private _proxy: AxiosProxyConfig | false | undefined;
+	private _proxy: AxiosProxyConfig | false | undefined | null = null;
 	private _userId: string | undefined;
 
 	// Parameters that can be set once, upon initialization
@@ -53,7 +53,9 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._apiKey = config?.apiKey;
 		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
 		// Proxy logic: user explicit value > httpsAgent set > default true
-		this._proxy = config?.proxy;
+		if (config && 'proxy' in config) {
+			this._proxy = config.proxy;
+		}
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
 		this.delay = config?.delay ?? 0;
 		this.maxRetries = config?.maxRetries ?? 0;
@@ -82,8 +84,8 @@ export class RettiwtConfig implements IRettiwtConfig {
 
 	/** Whether to use axios built-in proxy. */
 	public get proxy(): AxiosProxyConfig | false | undefined {
-		// User explicitly set proxy
-		if (this._proxy) {
+		// User explicitly set proxy , maybe undefined
+		if (this._proxy !== null) {
 			return this._proxy;
 		}
 		// httpsAgent set via proxyUrl → proxy should be false

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -82,7 +82,11 @@ export class RettiwtConfig implements IRettiwtConfig {
 		return this._httpsAgent;
 	}
 
-	/** Whether to use axios built-in proxy. */
+	/**
+	 * Axios built-in proxy configuration.
+	 *
+	 * Priority: user explicit value > httpsAgent set > default environment variables
+	 */
 	public get proxy(): AxiosProxyConfig | false | undefined {
 		// User explicitly set proxy , maybe undefined
 		if (this._proxy !== null) {

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -1,5 +1,6 @@
 import { Agent } from 'https';
 
+import { AxiosProxyConfig } from 'axios';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import { AuthService } from '../services/internal/AuthService';
@@ -35,7 +36,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	private _apiKey?: string;
 	private _headers: { [key: string]: string };
 	private _httpsAgent: Agent;
-	private _proxy: boolean | null = null;
+	private _proxy: AxiosProxyConfig | false | undefined;
 	private _userId: string | undefined;
 
 	// Parameters that can be set once, upon initialization
@@ -52,9 +53,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._apiKey = config?.apiKey;
 		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
 		// Proxy logic: user explicit value > httpsAgent set > default true
-		if (config?.proxy !== undefined) {
-			this._proxy = config.proxy;
-		}
+		this._proxy = config?.proxy;
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
 		this.delay = config?.delay ?? 0;
 		this.maxRetries = config?.maxRetries ?? 0;
@@ -82,10 +81,10 @@ export class RettiwtConfig implements IRettiwtConfig {
 	}
 
 	/** Whether to use axios built-in proxy. */
-	public get proxy(): false | undefined {
+	public get proxy(): AxiosProxyConfig | false | undefined {
 		// User explicitly set proxy
-		if (this._proxy !== null) {
-			return this._proxy ? undefined : false;
+		if (this._proxy) {
+			return this._proxy;
 		}
 		// httpsAgent set via proxyUrl → proxy should be false
 		if (this._httpsAgent instanceof HttpsProxyAgent) {
@@ -112,12 +111,12 @@ export class RettiwtConfig implements IRettiwtConfig {
 		};
 	}
 
-	public set proxyUrl(proxyUrl: URL | undefined) {
-		this._httpsAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : new Agent();
+	public set proxy(proxy: AxiosProxyConfig | false | undefined) {
+		this._proxy = proxy ?? undefined;
 	}
 
-	public set proxy(proxy: boolean | undefined) {
-		this._proxy = proxy ?? null;
+	public set proxyUrl(proxyUrl: URL | undefined) {
+		this._httpsAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : new Agent();
 	}
 }
 

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -35,6 +35,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	private _apiKey?: string;
 	private _headers: { [key: string]: string };
 	private _httpsAgent: Agent;
+	private _proxy: boolean | null = null;
 	private _userId: string | undefined;
 
 	// Parameters that can be set once, upon initialization
@@ -50,6 +51,10 @@ export class RettiwtConfig implements IRettiwtConfig {
 	public constructor(config?: IRettiwtConfig) {
 		this._apiKey = config?.apiKey;
 		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
+		// Proxy logic: user explicit value > httpsAgent set > default true
+		if (config?.proxy !== undefined) {
+			this._proxy = config.proxy;
+		}
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
 		this.delay = config?.delay ?? 0;
 		this.maxRetries = config?.maxRetries ?? 0;
@@ -76,6 +81,20 @@ export class RettiwtConfig implements IRettiwtConfig {
 		return this._httpsAgent;
 	}
 
+	/** Whether to use axios built-in proxy. */
+	public get proxy(): false | undefined {
+		// User explicitly set proxy
+		if (this._proxy !== null) {
+			return this._proxy ? undefined : false;
+		}
+		// httpsAgent set via proxyUrl → proxy should be false
+		if (this._httpsAgent instanceof HttpsProxyAgent) {
+			return false;
+		}
+		// Default: let axios use its default (env proxy)
+		return undefined;
+	}
+
 	/** The ID of the user associated with the API key, if any. */
 	public get userId(): string | undefined {
 		return this._userId;
@@ -95,6 +114,10 @@ export class RettiwtConfig implements IRettiwtConfig {
 
 	public set proxyUrl(proxyUrl: URL | undefined) {
 		this._httpsAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : new Agent();
+	}
+
+	public set proxy(proxy: boolean | undefined) {
+		this._proxy = proxy ?? null;
 	}
 }
 

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -82,11 +82,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 		return this._httpsAgent;
 	}
 
-	/**
-	 * Axios built-in proxy configuration.
-	 *
-	 * Priority: user explicit value > httpsAgent set > default environment variables
-	 */
+	/** Axios proxy config. Priority: User explicit → HttpsAgent → Env variables */
 	public get proxy(): AxiosProxyConfig | false | undefined {
 		// User explicitly set proxy , maybe undefined
 		if (this._proxy !== null) {

--- a/src/services/internal/AuthService.ts
+++ b/src/services/internal/AuthService.ts
@@ -107,6 +107,7 @@ export class AuthService {
 			}>('https://api.twitter.com/1.1/guest/activate.json', undefined, {
 				headers: cred.toHeader(),
 				httpsAgent: this._config.httpsAgent,
+				proxy: this._config.proxy,
 			})
 			.then((res) => {
 				cred.guestToken = res.data.guest_token;

--- a/src/services/internal/AuthService.ts
+++ b/src/services/internal/AuthService.ts
@@ -200,6 +200,7 @@ export class AuthService {
 				},
 				httpAgent: config.httpsAgent,
 				httpsAgent: config.httpsAgent,
+				proxy: config.proxy,
 				validateStatus: () => true,
 			});
 

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -130,6 +130,7 @@ export class FetcherService {
 			headers: this.config.headers,
 			httpAgent: this.config.httpsAgent,
 			httpsAgent: this.config.httpsAgent,
+			proxy: this.config.proxy,
 		});
 
 		// Parse HTML using linkedom
@@ -153,6 +154,7 @@ export class FetcherService {
 			const redirectResponse = await axios.get<string>(migrationRedirectionUrl[0], {
 				httpAgent: this.config.httpsAgent,
 				httpsAgent: this.config.httpsAgent,
+				proxy: this.config.proxy,
 			});
 
 			dom = new JSDOM(redirectResponse.data);
@@ -195,6 +197,7 @@ export class FetcherService {
 				},
 				httpAgent: this.config.httpsAgent,
 				httpsAgent: this.config.httpsAgent,
+				proxy: this.config.proxy,
 			});
 
 			dom = new JSDOM(formResponse.data);
@@ -312,6 +315,7 @@ export class FetcherService {
 		};
 		config.httpAgent = this.config.httpsAgent;
 		config.httpsAgent = this.config.httpsAgent;
+		config.proxy = this.config.proxy;
 		config.timeout = this._timeout;
 
 		// Using retries for error 404

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -175,6 +175,7 @@ export class UserService extends FetcherService {
 				},
 				httpAgent: this.config.httpsAgent,
 				httpsAgent: this.config.httpsAgent,
+				proxy: this.config.proxy,
 				validateStatus: () => true,
 			});
 

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -19,14 +19,27 @@ export interface IRettiwtConfig {
 	proxyUrl?: URL;
 
 	/**
-	 * Whether to use axios built-in proxy support.
+	 * Axios built-in proxy configuration.
 	 *
 	 * @remarks
-	 * - If user explicitly sets this, the user's value is used.
-	 * - If {@link proxyUrl} is set, this defaults to `false`.
-	 * - Otherwise, defaults to `true`.
+	 * Controls proxy behavior with the following priority:
+	 * 1. User explicitly set value → use user's proxy config
+	 * 2. {@link proxyUrl} is set → defaults to `false` (uses httpsAgent instead)
+	 * 3. Neither set → defaults to `undefined` (allows axios to use environment variables)
+	 *
+	 * @example
+	 * ```
+	 * // Use custom proxy config
+	 * { proxy: { host: '127.0.0.1', port: 8080 } }
+	 *
+	 * // Explicitly disable proxy
+	 * { proxy: false }
+	 *
+	 * // Use environment variables
+	 * { proxy: undefined }
+	 * ```
 	 */
-	proxy?: AxiosProxyConfig | false;
+	proxy?: AxiosProxyConfig | false | undefined;
 
 	/** The max wait time (in milli-seconds) for a response; if not set, Twitter server timeout is used. */
 	timeout?: number;

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -1,3 +1,5 @@
+import { AxiosProxyConfig } from 'axios';
+
 import { IErrorHandler } from './ErrorHandler';
 
 /**
@@ -24,7 +26,7 @@ export interface IRettiwtConfig {
 	 * - If {@link proxyUrl} is set, this defaults to `false`.
 	 * - Otherwise, defaults to `true`.
 	 */
-	proxy?: boolean;
+	proxy?: AxiosProxyConfig | false;
 
 	/** The max wait time (in milli-seconds) for a response; if not set, Twitter server timeout is used. */
 	timeout?: number;

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -16,6 +16,16 @@ export interface IRettiwtConfig {
 	 */
 	proxyUrl?: URL;
 
+	/**
+	 * Whether to use axios built-in proxy support.
+	 *
+	 * @remarks
+	 * - If user explicitly sets this, the user's value is used.
+	 * - If {@link proxyUrl} is set, this defaults to `false`.
+	 * - Otherwise, defaults to `true`.
+	 */
+	proxy?: boolean;
+
 	/** The max wait time (in milli-seconds) for a response; if not set, Twitter server timeout is used. */
 	timeout?: number;
 


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/openclaw/openclaw/issues/41820

## ❓ Type of Change

<!-- Select all that apply -->

- [ ] 📖 Documentation (docs, README, or comments)
- [√ ] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

This issue relates to proxies. Most proxy software does not provide local HTTPS support, while Axios reads the https_proxy environment variable — which points to an HTTP proxy. This mismatch causes requests to fail. The solution is to disable the proxy by setting proxy to false. Therefore, I referred to other Q&As to organize the additional parameters for this part.

## 📝 Checklist

- [ ] Issue/discussion linked above.
- [ ] Documentation updated (if needed).
- [ ] Code follows project conventions and ESLint rules.
- [ ] No sensitive data or credentials are included.

<!--
If you need help, mention @Rishikant181 or ask in the discussions.
-->
