### PR TITLE
Updated the way in which proxies are configured

### DIFF
--- a/src/Rettiwt.ts
+++ b/src/Rettiwt.ts
@@ -1,3 +1,5 @@
+import { AxiosProxyConfig } from 'axios';
+
 import { RettiwtConfig } from './models/RettiwtConfig';
 import { DirectMessageService } from './services/public/DirectMessageService';
 import { ListService } from './services/public/ListService';
@@ -95,8 +97,8 @@ export class Rettiwt {
 		this._config.headers = headers;
 	}
 
-	/** Set the proxy URL for the current instance. */
-	public set proxyUrl(proxyUrl: URL) {
-		this._config.proxyUrl = proxyUrl;
+	/** Set the proxy for the current instance. */
+	public set proxy(proxy: AxiosProxyConfig | string | undefined | null) {
+		this._config.proxy = proxy;
 	}
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ Program.parse();
 const RettiwtInstance = new Rettiwt({
 	apiKey: process.env.API_KEY ?? (Program.opts().key as string),
 	logging: Program.opts().log ? true : false,
-	proxyUrl: Program.opts().proxy as URL,
+	proxy: Program.opts().proxy as string,
 	timeout: Program.opts().timeout ? Number(Program.opts().timeout) : undefined,
 	maxRetries: Program.opts().retries as number,
 	delay: Program.opts().delay as number,

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -36,7 +36,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	private _apiKey?: string;
 	private _headers: { [key: string]: string };
 	private _httpsAgent: Agent;
-	private _proxy: AxiosProxyConfig | false | undefined | null = null;
+	private _proxy?: AxiosProxyConfig | string | null;
 	private _userId: string | undefined;
 
 	// Parameters that can be set once, upon initialization
@@ -51,11 +51,8 @@ export class RettiwtConfig implements IRettiwtConfig {
 	 */
 	public constructor(config?: IRettiwtConfig) {
 		this._apiKey = config?.apiKey;
-		this._httpsAgent = config?.proxyUrl ? new HttpsProxyAgent(config?.proxyUrl) : new Agent();
-		// Proxy logic: user explicit value > httpsAgent set > default true
-		if (config && 'proxy' in config) {
-			this._proxy = config.proxy;
-		}
+		this._httpsAgent = typeof config?.proxy === 'string' ? new HttpsProxyAgent(config.proxy) : new Agent();
+		this._proxy = config?.proxy;
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
 		this.delay = config?.delay ?? 0;
 		this.maxRetries = config?.maxRetries ?? 0;
@@ -73,6 +70,27 @@ export class RettiwtConfig implements IRettiwtConfig {
 		return this._apiKey;
 	}
 
+	/**
+	 * The Axios proxy configuration to use.
+	 *
+	 * @remarks
+	 * <br>
+	 * - If `proxy` is set, Axios' built-in env-variable-based proxy is disabled.
+	 */
+	public get axiosProxyConfig(): AxiosProxyConfig | false | undefined {
+		// If user explicitly set to null or a proxy URL, disable Axios' built-in proxy
+		if (this._proxy === null || typeof this._proxy === 'string') {
+			return false;
+		}
+		// If user has set an AxiosProxyConfig, use that
+		if (this._proxy !== undefined) {
+			return this._proxy;
+		}
+
+		// Default: Let axios use it's built-in env-variable-based proxy.
+		return undefined;
+	}
+
 	public get headers(): { [key: string]: string } {
 		return this._headers;
 	}
@@ -80,20 +98,6 @@ export class RettiwtConfig implements IRettiwtConfig {
 	/** The HTTPS agent instance to use. */
 	public get httpsAgent(): Agent {
 		return this._httpsAgent;
-	}
-
-	/** Axios proxy config. Priority: User explicit → HttpsAgent → Env variables */
-	public get proxy(): AxiosProxyConfig | false | undefined {
-		// User explicitly set proxy , maybe undefined
-		if (this._proxy !== null) {
-			return this._proxy;
-		}
-		// httpsAgent set via proxyUrl → proxy should be false
-		if (this._httpsAgent instanceof HttpsProxyAgent) {
-			return false;
-		}
-		// Default: let axios use its default (env proxy)
-		return undefined;
 	}
 
 	/** The ID of the user associated with the API key, if any. */
@@ -113,12 +117,11 @@ export class RettiwtConfig implements IRettiwtConfig {
 		};
 	}
 
-	public set proxy(proxy: AxiosProxyConfig | false | undefined) {
-		this._proxy = proxy ?? undefined;
-	}
+	public set proxy(proxy: AxiosProxyConfig | string | null | undefined) {
+		// Update HTTPs agent
+		this._httpsAgent = typeof proxy === 'string' ? new HttpsProxyAgent(proxy) : new Agent();
 
-	public set proxyUrl(proxyUrl: URL | undefined) {
-		this._httpsAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : new Agent();
+		this._proxy = proxy;
 	}
 }
 

--- a/src/services/internal/AuthService.ts
+++ b/src/services/internal/AuthService.ts
@@ -200,7 +200,7 @@ export class AuthService {
 				},
 				httpAgent: config.httpsAgent,
 				httpsAgent: config.httpsAgent,
-				proxy: config.proxy,
+				proxy: config.axiosProxyConfig,
 				validateStatus: () => true,
 			});
 
@@ -253,7 +253,7 @@ export class AuthService {
 			}>('https://api.twitter.com/1.1/guest/activate.json', undefined, {
 				headers: cred.toHeader(),
 				httpsAgent: this._config.httpsAgent,
-				proxy: this._config.proxy,
+				proxy: this._config.axiosProxyConfig,
 			})
 			.then((res) => {
 				cred.guestToken = res.data.guest_token;

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -130,7 +130,7 @@ export class FetcherService {
 			headers: this.config.headers,
 			httpAgent: this.config.httpsAgent,
 			httpsAgent: this.config.httpsAgent,
-			proxy: this.config.proxy,
+			proxy: this.config.axiosProxyConfig,
 		});
 
 		// Parse HTML using linkedom
@@ -154,7 +154,7 @@ export class FetcherService {
 			const redirectResponse = await axios.get<string>(migrationRedirectionUrl[0], {
 				httpAgent: this.config.httpsAgent,
 				httpsAgent: this.config.httpsAgent,
-				proxy: this.config.proxy,
+				proxy: this.config.axiosProxyConfig,
 			});
 
 			dom = new JSDOM(redirectResponse.data);
@@ -197,7 +197,7 @@ export class FetcherService {
 				},
 				httpAgent: this.config.httpsAgent,
 				httpsAgent: this.config.httpsAgent,
-				proxy: this.config.proxy,
+				proxy: this.config.axiosProxyConfig,
 			});
 
 			dom = new JSDOM(formResponse.data);
@@ -296,7 +296,7 @@ export class FetcherService {
 		};
 		config.httpAgent = this.config.httpsAgent;
 		config.httpsAgent = this.config.httpsAgent;
-		config.proxy = this.config.proxy;
+		config.proxy = this.config.axiosProxyConfig;
 		config.timeout = this._timeout;
 
 		// Using retries for error 404

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -12,34 +12,34 @@ export interface IRettiwtConfig {
 	apiKey?: string;
 
 	/**
-	 * Optional URL to proxy server to use for requests to Twitter API.
-	 *
-	 * @remarks When deploying to cloud platforms, if setting {@link IRettiwtConfig.authProxyUrl} does not resolve Error 429, then this might be required.
-	 */
-	proxyUrl?: URL;
-
-	/**
-	 * Axios built-in proxy configuration.
+	 * The proxy to use.
 	 *
 	 * @remarks
-	 * Controls proxy behavior with the following priority:
-	 * 1. User explicitly set value → use user's proxy config
-	 * 2. {@link proxyUrl} is set → defaults to `false` (uses httpsAgent instead)
-	 * 3. Neither set → defaults to `undefined` (allows axios to use environment variables)
+	 * <br>
+	 * - If set to anything besides `undefined`, disables Axios' built-in environment variable-set proxy.
 	 *
 	 * @example
 	 * ```
-	 * // Use custom proxy config
-	 * { proxy: { host: '127.0.0.1', port: 8080 } }
+	 * // Use custom proxy config via config object
+	 * {
+	 *   proxy: {
+	 *     host: '127.0.0.1',
+	 *     port: 8080
+	 *   }
+	 * }
 	 *
-	 * // Explicitly disable proxy
-	 * { proxy: false }
+	 * // Use custom proxy config via URL
+	 * {
+	 *   proxy: 'https://127.0.0.1:8080'
+	 * }
 	 *
-	 * // Use environment variables
-	 * { proxy: undefined }
+	 * // Use Axios environment variable for proxy
+	 * {
+	 *   proxy: undefined
+	 * }
 	 * ```
 	 */
-	proxy?: AxiosProxyConfig | false | undefined;
+	proxy?: AxiosProxyConfig | string | null;
 
 	/** The max wait time (in milli-seconds) for a response; if not set, Twitter server timeout is used. */
 	timeout?: number;


### PR DESCRIPTION
## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [X] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

A proxy can now be configured by any one of the 3 methods:
- By passing a URL
- By passing an `AxiosProxyConfig` object (for advanced proxy configuration like username and password)
- By using environment variables (Axios' built-in support)

```ts
// Configuring an HTTPS proxy using it's URL
const rettiwt = new Rettiwt({
  proxy: 'https://127.0.0.1:8080'
});
```

```ts
// Configuring an HTTPS proxy using an AxiosProxyConfig object
const rettiwt = new Rettiwt({
  proxy: {
    protocol: 'https',
    host: '127.0.0.1',
    port: 8080,
    auth: {
      username: 'user1',
      password: 'pass1'
    }
});
```

```bash
# Configuring an HTTPS proxy using env var
HTTPS_PROXY='https://127.0.0.1:8080' <your_script_exec_command>
```

**Notes**:
- Configuring a proxy either by passing URL or `AxiosProxyConfig` overrides the proxy configured in env var.
- You can disable the proxy set in env var by setting `proxy: null`.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.
