### PR TITLE
Added SOCKS proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"https-proxy-agent": "^7.0.6",
 				"jsdom": "^27.2.0",
 				"node-html-parser": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5",
 				"x-client-transaction-id": "^0.2.0"
 			},
 			"bin": {
@@ -2867,6 +2868,15 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -4387,6 +4397,44 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"https-proxy-agent": "^7.0.6",
 		"jsdom": "^27.2.0",
 		"node-html-parser": "^7.0.1",
+		"socks-proxy-agent": "^8.0.5",
 		"x-client-transaction-id": "^0.2.0"
 	}
 }

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -4,6 +4,7 @@ import { Agent as HttpsAgent } from 'https';
 import { AxiosProxyConfig } from 'axios';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { SocksProxyAgent } from 'socks-proxy-agent';
 
 import { AuthService } from '../services/internal/AuthService';
 import { IErrorHandler } from '../types/ErrorHandler';
@@ -68,13 +69,9 @@ export class RettiwtConfig implements IRettiwtConfig {
 		};
 
 		// Initializing the HTTP(S) agent(s)
-		if (typeof config?.proxy === 'string') {
-			this._httpAgent = new HttpProxyAgent(config.proxy);
-			this._httpsAgent = new HttpsProxyAgent(config.proxy);
-		} else {
-			this._httpAgent = new HttpAgent();
-			this._httpsAgent = new HttpsAgent();
-		}
+		const agents = this._getRequestAgents(config?.proxy);
+		this._httpAgent = agents.httpAgent;
+		this._httpsAgent = agents.httpsAgent;
 	}
 
 	public get apiKey(): string | undefined {
@@ -134,16 +131,43 @@ export class RettiwtConfig implements IRettiwtConfig {
 	}
 
 	public set proxy(proxy: AxiosProxyConfig | string | null | undefined) {
-		// Update HTTPs agent
-		if (typeof proxy === 'string') {
-			this._httpAgent = new HttpProxyAgent(proxy);
-			this._httpsAgent = new HttpsProxyAgent(proxy);
-		} else {
-			this._httpAgent = new HttpAgent();
-			this._httpsAgent = new HttpsAgent();
-		}
+		// Update HTTP(s) agents
+		const agents = this._getRequestAgents(proxy);
+		this._httpAgent = agents.httpAgent;
+		this._httpsAgent = agents.httpsAgent;
 
 		this._proxy = proxy;
+	}
+
+	/**
+	 * Returns the appropriate HTTP(s) agents based on the type of proxy config.
+	 *
+	 * @param proxy - The proxy configuration.
+	 *
+	 * @returns The HTTP(s) agents.
+	 */
+	private _getRequestAgents(proxy?: AxiosProxyConfig | string | null): {
+		httpAgent: HttpAgent;
+		httpsAgent: HttpsAgent;
+	} {
+		let httpAgent: HttpAgent | undefined;
+		let httpsAgent: HttpsAgent | undefined;
+
+		if (typeof proxy === 'string' && (proxy.startsWith('http://') || proxy.startsWith('https://'))) {
+			httpAgent = new HttpProxyAgent(proxy);
+			httpsAgent = new HttpsProxyAgent(proxy);
+		} else if (typeof proxy === 'string' && proxy.startsWith('socks')) {
+			httpAgent = new SocksProxyAgent(proxy);
+			httpsAgent = new SocksProxyAgent(proxy);
+		} else {
+			httpAgent = new HttpAgent();
+			httpsAgent = new HttpsAgent();
+		}
+
+		return {
+			httpAgent: httpAgent,
+			httpsAgent: httpsAgent,
+		};
 	}
 }
 


### PR DESCRIPTION
## 🔗 Related Issue

Closes #645 

## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [X] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

To use a SOCKS (4/5) proxy, pass the proxy URL while configuring Rettiwt:

```ts
const rettiwt = new Rettiwt({
  proxy: 'socks5://127.0.0.1:12345'
});
```

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.