### PR TITLE
`request` method of `FetcherService` now returns the raw AxiosReponse instead of just the response body data

### DIFF
--- a/src/services/public/DirectMessageService.ts
+++ b/src/services/public/DirectMessageService.ts
@@ -64,7 +64,7 @@ export class DirectMessageService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -139,7 +139,7 @@ export class DirectMessageService extends FetcherService {
 			});
 
 			// Deserializing response
-			const data = Extractors[resource](response);
+			const data = Extractors[resource](response.data);
 
 			return data;
 		}
@@ -151,7 +151,7 @@ export class DirectMessageService extends FetcherService {
 			const response = await this.request<IInboxInitialResponse>(resource, {});
 
 			// Deserializing response
-			const data = Extractors[resource](response);
+			const data = Extractors[resource](response.data);
 
 			return data;
 		}

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -258,12 +258,28 @@ export class FetcherService {
 	 *
 	 * @typeParam T - The type of the returned response data.
 	 *
-	 * @returns The raw HTTP response received.
+	 * @returns The raw Axios response.
+	 *
+	 * @example
+	 *
+	 * #### Fetching the raw details of a single user, using their username
+	 * ```ts
+	 * import { FetcherService, ResourceType } from 'rettiwt-api';
+	 *
+	 * // Creating a new FetcherService instance using the given 'API_KEY'
+	 * const fetcher = new FetcherService({ apiKey: API_KEY });
+	 *
+	 * // Fetching the details of the User with username 'user1'
+	 * fetcher.request(ResourceType.USER_DETAILS_BY_USERNAME, { id: 'user1' })
+	 * .then(res => {
+	 * 	console.log(res);
+	 * })
+	 * .catch(err => {
+	 * 	console.log(err);
+	 * });
+	 * ```
 	 */
-	protected async requestWithResponse<T = unknown>(
-		resource: ResourceType,
-		args: IFetchArgs | IPostArgs,
-	): Promise<AxiosResponse<T>> {
+	public async request<T = unknown>(resource: ResourceType, args: IFetchArgs | IPostArgs): Promise<AxiosResponse<T>> {
 		/** The current retry number. */
 		let retry = 0;
 
@@ -354,40 +370,5 @@ export class FetcherService {
 
 		/** If request not successful even after retries, throw the error */
 		throw error;
-	}
-
-	/**
-	 * Makes an HTTP request according to the given parameters.
-	 *
-	 * @param resource - The requested resource.
-	 * @param args - The args to be used for the request.
-	 *
-	 * @typeParam T - The type of the returned response data.
-	 *
-	 * @returns The parsed HTTP response data.
-	 *
-	 * @example
-	 *
-	 * #### Fetching the raw details of a single user, using their username
-	 * ```ts
-	 * import { FetcherService, ResourceType } from 'rettiwt-api';
-	 *
-	 * // Creating a new FetcherService instance using the given 'API_KEY'
-	 * const fetcher = new FetcherService({ apiKey: API_KEY });
-	 *
-	 * // Fetching the details of the User with username 'user1'
-	 * fetcher.request(ResourceType.USER_DETAILS_BY_USERNAME, { id: 'user1' })
-	 * .then(res => {
-	 * 	console.log(res);
-	 * })
-	 * .catch(err => {
-	 * 	console.log(err);
-	 * });
-	 * ```
-	 */
-	public async request<T = unknown>(resource: ResourceType, args: IFetchArgs | IPostArgs): Promise<T> {
-		const response = await this.requestWithResponse<T>(resource, args);
-
-		return response.data;
 	}
 }

--- a/src/services/public/ListService.ts
+++ b/src/services/public/ListService.ts
@@ -59,7 +59,7 @@ export class ListService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -100,7 +100,7 @@ export class ListService extends FetcherService {
 		const response = await this.request<IListDetailsResponse>(resource, { id: id });
 
 		// Deserializing response
-		const data = Extractors[resource](response, id);
+		const data = Extractors[resource](response.data, id);
 
 		return data;
 	}
@@ -145,7 +145,7 @@ export class ListService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -186,7 +186,7 @@ export class ListService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -231,7 +231,7 @@ export class ListService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		// Sorting the tweets by date, from recent to oldest
 		data.list.sort((a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf());

--- a/src/services/public/SpaceService.ts
+++ b/src/services/public/SpaceService.ts
@@ -58,7 +58,7 @@ export class SpaceService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}

--- a/src/services/public/TweetService.ts
+++ b/src/services/public/TweetService.ts
@@ -80,7 +80,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -146,7 +146,7 @@ export class TweetService extends FetcherService {
 			const response = await this.request<ITweetRepliesResponse>(resource, { id: id });
 
 			// Deserializing response
-			const data = Extractors[resource](response, id);
+			const data = Extractors[resource](response.data, id);
 
 			return data as T extends string ? Tweet | undefined : Tweet[];
 		}
@@ -158,7 +158,7 @@ export class TweetService extends FetcherService {
 			const response = await this.request<ITweetDetailsBulkResponse>(resource, { ids: id });
 
 			// Deserializing response
-			const data = Extractors[resource](response, id);
+			const data = Extractors[resource](response.data, id);
 
 			return data as T extends string ? Tweet | undefined : Tweet[];
 		}
@@ -170,7 +170,7 @@ export class TweetService extends FetcherService {
 			const response = await this.request<ITweetDetailsResponse>(resource, { id: String(id) });
 
 			// Deserializing response
-			const data = Extractors[resource](response, String(id));
+			const data = Extractors[resource](response.data, String(id));
 
 			return data as T extends string ? Tweet | undefined : Tweet[];
 		}
@@ -210,7 +210,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -253,7 +253,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -348,12 +348,12 @@ export class TweetService extends FetcherService {
 				tweet: options,
 			});
 
-			return Extractors[ResourceType.TWEET_POST_NOTE](response);
+			return Extractors[ResourceType.TWEET_POST_NOTE](response.data);
 		}
 
 		const response = await this.request<ITweetPostResponse>(ResourceType.TWEET_POST, { tweet: options });
 
-		return Extractors[ResourceType.TWEET_POST](response);
+		return Extractors[ResourceType.TWEET_POST](response.data);
 	}
 
 	/**
@@ -406,7 +406,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -443,7 +443,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetRetweetResponse>(resource, { id: id });
 
 		// Deserializing response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -486,7 +486,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -528,7 +528,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetScheduleResponse>(resource, { tweet: options });
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -576,7 +576,7 @@ export class TweetService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		// Sorting the tweets by date, from recent to oldest
 		data.list.sort((a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf());
@@ -685,7 +685,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetUnbookmarkResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -722,7 +722,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetUnlikeResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -759,7 +759,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetUnpostResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -796,7 +796,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetUnretweetResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -833,7 +833,7 @@ export class TweetService extends FetcherService {
 		const response = await this.request<ITweetUnscheduleResponse>(resource, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -876,7 +876,7 @@ export class TweetService extends FetcherService {
 			await this.request<IMediaInitializeUploadResponse>(ResourceType.MEDIA_UPLOAD_INITIALIZE, {
 				upload: { size: size },
 			})
-		).media_id_string;
+		).data.media_id_string;
 
 		// APPEND
 		await this.request<unknown>(ResourceType.MEDIA_UPLOAD_APPEND, { upload: { id: id, media: media } });

--- a/src/services/public/UserService.ts
+++ b/src/services/public/UserService.ts
@@ -144,7 +144,7 @@ export class UserService extends FetcherService {
 		const response = await this.request<IUserAboutResponse>(resource, { id: userName });
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -187,7 +187,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -245,7 +245,7 @@ export class UserService extends FetcherService {
 			showVerifiedFollowers,
 		});
 
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -288,7 +288,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -327,7 +327,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -368,7 +368,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -390,7 +390,7 @@ export class UserService extends FetcherService {
 		const resource = ResourceType.USER_PASSWORD_CHANGE;
 
 		// Changing the password
-		const response = await this.requestWithResponse<IUserChangePasswordResponse>(resource, {
+		const response = await this.request<IUserChangePasswordResponse>(resource, {
 			changePassword: { currentPassword, newPassword },
 		});
 
@@ -443,7 +443,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Getting the updated username
-		const updatedUsername = Extractors[resource](response);
+		const updatedUsername = Extractors[resource](response.data);
 
 		return updatedUsername?.toLowerCase() === username.toLowerCase();
 	}
@@ -558,7 +558,7 @@ export class UserService extends FetcherService {
 			const response = await this.request<IUserDetailsBulkResponse>(resource, { ids: id });
 
 			// Deserializing response
-			const data = Extractors[resource](response, id);
+			const data = Extractors[resource](response.data, id);
 
 			return data;
 		}
@@ -585,7 +585,7 @@ export class UserService extends FetcherService {
 			const response = await this.request<IUserDetailsResponse>(resource, { id: id ?? this.config.userId });
 
 			// Deserializing response
-			const data = Extractors[resource](response);
+			const data = Extractors[resource](response.data);
 
 			return data;
 		}
@@ -625,7 +625,7 @@ export class UserService extends FetcherService {
 		const response = await this.request<IUserFollowResponse>(ResourceType.USER_FOLLOW, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -666,7 +666,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -709,7 +709,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -752,7 +752,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -795,7 +795,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -837,7 +837,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -879,7 +879,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -922,7 +922,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -979,7 +979,7 @@ export class UserService extends FetcherService {
 			});
 
 			// Deserializing response
-			const notifications = Extractors[resource](response);
+			const notifications = Extractors[resource](response.data);
 
 			// Sorting the notifications by time, from oldest to recent
 			notifications.list.sort((a, b) => new Date(a.receivedAt).valueOf() - new Date(b.receivedAt).valueOf());
@@ -1036,7 +1036,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -1083,7 +1083,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -1126,7 +1126,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -1169,7 +1169,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -1217,7 +1217,7 @@ export class UserService extends FetcherService {
 		});
 
 		// Deserializing response
-		const data = Extractors[resource](response);
+		const data = Extractors[resource](response.data);
 
 		return data;
 	}
@@ -1254,7 +1254,7 @@ export class UserService extends FetcherService {
 		const response = await this.request<IUserUnfollowResponse>(ResourceType.USER_UNFOLLOW, { id: id });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -1319,7 +1319,7 @@ export class UserService extends FetcherService {
 		const response = await this.request<IUserProfileUpdateResponse>(resource, { profileOptions: validatedOptions });
 
 		// Deserializing the response
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -1345,7 +1345,7 @@ export class UserService extends FetcherService {
 			profileBanner: validatedBanner,
 		});
 
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}
@@ -1371,7 +1371,7 @@ export class UserService extends FetcherService {
 			profileImage: validatedImage,
 		});
 
-		const data = Extractors[resource](response) ?? false;
+		const data = Extractors[resource](response.data) ?? false;
 
 		return data;
 	}


### PR DESCRIPTION
## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [ ] 🐞 Bug fix (non-breaking fix for an issue)
- [X] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [ ] ⚠️ Breaking change (affects existing usage)

## 📚 Description

`request` method of `FetcherService` earlier used to return the parsed response body, instead of the raw Axios response object. With this PR, the method now returns the full, raw Axios reponse.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.