### PR TITLE
Fix User parsing when pinned_tweet_ids_str is missing

### DIFF
--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -49,7 +49,7 @@ export class User implements IUser {
 		this.followingsCount = user.legacy.friends_count;
 		this.statusesCount = user.legacy.statuses_count;
 		this.location = user.location?.location ?? user.legacy.location ?? undefined;
-		this.pinnedTweet = user.legacy.pinned_tweet_ids_str[0];
+		this.pinnedTweet = user.legacy.pinned_tweet_ids_str?.[0];
 		this.profileBanner = user.legacy.profile_banner_url;
 		this.profileImage = user.avatar?.image_url ?? user.legacy.profile_image_url_https ?? '';
 	}


### PR DESCRIPTION
## 🔗 Related Issue

https://github.com/Rishikant181/Rettiwt-API/issues/862

  ## ❓ Type of Change

  <!-- Select all that apply -->

  - [ ] 📖 Documentation (docs, README, or comments)
  - [x] 🐞 Bug fix (non-breaking fix for an issue)
  - [ ] 👌 Enhancement (improvement to existing functionality)
  - [ ] ✨ New feature (adds new functionality)
  - [ ] 🧹 Chore (build, tooling, dependencies)
  - [ ] ⚠️ Breaking change (affects existing usage)

  ## 📚 Description

  Fixes a parsing bug in `src/models/data/User.ts` when X `UserByRestId` responses omit
  `legacy.pinned_tweet_ids_str`.

  Previously, the parser accessed `user.legacy.pinned_tweet_ids_str[0]`, which could throw a
  `TypeError` when the field was absent even though the response was otherwise valid and the profile
  data remained usable.

  This change makes the access safe with optional chaining so `pinnedTweet` stays `undefined` when
  the field is missing, without changing the public behavior for valid existing cases.

  ## 📝 Checklist

  - [ ] Issue/discussion linked above.
  - [ ] Documentation updated (if needed).
  - [x] Code follows project conventions and ESLint rules.
  - [x] No sensitive data or credentials are included.