### PR TITLE
Fixed an issue with deserialization of User base type

### DIFF
--- a/src/models/data/User.ts
+++ b/src/models/data/User.ts
@@ -25,7 +25,7 @@ export class User implements IUser {
 	public isVerified: boolean;
 	public likeCount: number;
 	public location?: string;
-	public pinnedTweet?: string;
+	public pinnedTweets: string[];
 	public profileBanner?: string;
 	public profileImage: string;
 	public statusesCount: number;
@@ -49,7 +49,7 @@ export class User implements IUser {
 		this.followingsCount = user.legacy.friends_count;
 		this.statusesCount = user.legacy.statuses_count;
 		this.location = user.location?.location ?? user.legacy.location ?? undefined;
-		this.pinnedTweet = user.legacy.pinned_tweet_ids_str[0];
+		this.pinnedTweets = user.legacy.pinned_tweet_ids_str ?? [];
 		this.profileBanner = user.legacy.profile_banner_url;
 		this.profileImage = user.avatar?.image_url ?? user.legacy.profile_image_url_https ?? '';
 	}
@@ -177,7 +177,7 @@ export class User implements IUser {
 			isVerified: this.isVerified,
 			likeCount: this.likeCount,
 			location: this.location,
-			pinnedTweet: this.pinnedTweet,
+			pinnedTweets: this.pinnedTweets,
 			profileBanner: this.profileBanner,
 			profileImage: this.profileImage,
 			statusesCount: this.statusesCount,

--- a/src/types/data/User.ts
+++ b/src/types/data/User.ts
@@ -37,8 +37,8 @@ export interface IUser {
 	/** The location of user as provided by user. */
 	location?: string;
 
-	/** The rest id of the tweet pinned in the user's profile. */
-	pinnedTweet?: string;
+	/** The rest IDs of the tweets pinned in the user's profile. */
+	pinnedTweets: string[];
 
 	/** The url of the profile banner image. */
 	profileBanner?: string;

--- a/src/types/raw/base/User.ts
+++ b/src/types/raw/base/User.ts
@@ -116,7 +116,7 @@ export interface IUserLegacy {
 	listed_count: number;
 	media_count: number;
 	normal_followers_count: number;
-	pinned_tweet_ids_str: string[];
+	pinned_tweet_ids_str?: string[];
 	possibly_sensitive: boolean;
 	profile_banner_url: string;
 	profile_image_url_https?: string;


### PR DESCRIPTION
## 🔗 Related Issue

Closes #862 

## ❓ Type of Change

- [ ] 📖 Documentation (docs, README, or comments)
- [X] 🐞 Bug fix (non-breaking fix for an issue)
- [ ] 👌 Enhancement (improvement to existing functionality)
- [ ] ✨ New feature (adds new functionality)
- [ ] 🧹 Chore (build, tooling, dependencies)
- [X] ⚠️ Breaking change (affects existing usage)

## 📚 Description

The pinned tweets list field of the raw `IRawUser` base type from Twitter is now optional in Twitter APIs, which broke deserialization pipeline, resulting in the linked issue. This fix, changes the `pinnedTweet` field to `pinnedTweets`, so that instead of a single pinned tweet's rest ID being returned on the user details, the list of IDs of the pinned tweets are returned. If no pinned tweets exist, it returns an empty array.

## 📝 Checklist

- [X] Issue/discussion linked above.
- [X] Documentation updated (if needed).
- [X] Code follows project conventions and ESLint rules.
- [X] No sensitive data or credentials are included.