### PR TITLE
feat(config): add adapter and fetch options, use shared Axios instance

### DIFF
--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -45,7 +45,6 @@ export class RettiwtConfig implements IRettiwtConfig {
 	private _userId: string | undefined;
 
 	// Parameters that can be set once, upon initialization
-	public readonly adapter?: NonNullable<AxiosRequestConfig['adapter']>;
 	public readonly delay?: number | (() => number | Promise<number>);
 	public readonly errorHandler?: IErrorHandler;
 	public readonly fetch?: typeof fetch;
@@ -61,9 +60,8 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._apiKey = config?.apiKey;
 		this._proxy = config?.proxy;
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
-		this.adapter = config?.adapter ?? (config?.fetch !== undefined ? 'fetch' : undefined);
-		this.fetch = config?.fetch;
 		this.delay = config?.delay ?? 0;
+		this.fetch = config?.fetch;
 		this.maxRetries = config?.maxRetries ?? 0;
 		this.errorHandler = config?.errorHandler;
 		this.responseMiddleware = config?.responseMiddleware;
@@ -165,7 +163,7 @@ export class RettiwtConfig implements IRettiwtConfig {
 	}
 
 	/**
-	 * Creates the shared Axios instance with the current configuration.
+	 * Creates the shared HTTP client instance with the current configuration.
 	 *
 	 * @returns The configured Axios instance.
 	 */
@@ -176,11 +174,8 @@ export class RettiwtConfig implements IRettiwtConfig {
 			proxy: this.axiosProxyConfig,
 		};
 
-		if (this.adapter !== undefined) {
-			config.adapter = this.adapter;
-		}
-
 		if (this.fetch !== undefined) {
+			config.adapter = 'fetch';
 			config.env = { fetch: this.fetch };
 		}
 

--- a/src/models/RettiwtConfig.ts
+++ b/src/models/RettiwtConfig.ts
@@ -1,7 +1,7 @@
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 
-import { AxiosProxyConfig, AxiosResponse } from 'axios';
+import { AxiosInstance, AxiosProxyConfig, AxiosRequestConfig, AxiosResponse, create } from 'axios';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SocksProxyAgent } from 'socks-proxy-agent';
@@ -40,12 +40,15 @@ export class RettiwtConfig implements IRettiwtConfig {
 	private _headers: { [key: string]: string };
 	private _httpAgent: HttpAgent;
 	private _httpsAgent: HttpsAgent;
+	private _instance: AxiosInstance;
 	private _proxy?: AxiosProxyConfig | string | null;
 	private _userId: string | undefined;
 
 	// Parameters that can be set once, upon initialization
+	public readonly adapter?: NonNullable<AxiosRequestConfig['adapter']>;
 	public readonly delay?: number | (() => number | Promise<number>);
 	public readonly errorHandler?: IErrorHandler;
+	public readonly fetch?: typeof fetch;
 	public readonly logging?: boolean;
 	public readonly maxRetries: number;
 	public readonly responseMiddleware?: (response: AxiosResponse) => void | Promise<void>;
@@ -58,6 +61,8 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._apiKey = config?.apiKey;
 		this._proxy = config?.proxy;
 		this._userId = config?.apiKey ? AuthService.getUserId(config?.apiKey) : undefined;
+		this.adapter = config?.adapter ?? (config?.fetch !== undefined ? 'fetch' : undefined);
+		this.fetch = config?.fetch;
 		this.delay = config?.delay ?? 0;
 		this.maxRetries = config?.maxRetries ?? 0;
 		this.errorHandler = config?.errorHandler;
@@ -74,6 +79,9 @@ export class RettiwtConfig implements IRettiwtConfig {
 		const agents = this._getRequestAgents(config?.proxy);
 		this._httpAgent = agents.httpAgent;
 		this._httpsAgent = agents.httpsAgent;
+
+		// Creating the shared Axios instance
+		this._instance = this._createAxiosInstance();
 	}
 
 	public get apiKey(): string | undefined {
@@ -115,6 +123,16 @@ export class RettiwtConfig implements IRettiwtConfig {
 		return this._httpsAgent;
 	}
 
+	/**
+	 * The shared HTTP client instance used for all HTTP requests.
+	 *
+	 * @remarks The instance is configured with the proxy/adapter/timeout/fetch settings
+	 * from this config, and is updated when the `proxy` is changed dynamically.
+	 */
+	public get instance(): AxiosInstance {
+		return this._instance;
+	}
+
 	/** The ID of the user associated with the API key, if any. */
 	public get userId(): string | undefined {
 		return this._userId;
@@ -139,6 +157,38 @@ export class RettiwtConfig implements IRettiwtConfig {
 		this._httpsAgent = agents.httpsAgent;
 
 		this._proxy = proxy;
+
+		// Update the shared instance defaults
+		this._instance.defaults.httpAgent = this._httpAgent;
+		this._instance.defaults.httpsAgent = this._httpsAgent;
+		this._instance.defaults.proxy = this.axiosProxyConfig;
+	}
+
+	/**
+	 * Creates the shared Axios instance with the current configuration.
+	 *
+	 * @returns The configured Axios instance.
+	 */
+	private _createAxiosInstance(): AxiosInstance {
+		const config: AxiosRequestConfig = {
+			httpAgent: this._httpAgent,
+			httpsAgent: this._httpsAgent,
+			proxy: this.axiosProxyConfig,
+		};
+
+		if (this.adapter !== undefined) {
+			config.adapter = this.adapter;
+		}
+
+		if (this.fetch !== undefined) {
+			config.env = { fetch: this.fetch };
+		}
+
+		if (this.timeout !== undefined) {
+			config.timeout = this.timeout;
+		}
+
+		return create(config);
 	}
 
 	/**

--- a/src/services/internal/AuthService.ts
+++ b/src/services/internal/AuthService.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 
 import { Cookie } from 'cookiejar';
 
@@ -192,17 +192,17 @@ export class AuthService {
 					.map((item) => new Cookie(item)),
 			);
 
-			const refreshResponse = await axios.get('https://x.com/i/api/1.1/account/verify_credentials.json', {
-				headers: {
-					...cred.toHeader(),
-					authorization:
-						'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA',
+			const refreshResponse = await config.instance.get(
+				'https://x.com/i/api/1.1/account/verify_credentials.json',
+				{
+					headers: {
+						...cred.toHeader(),
+						authorization:
+							'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA',
+					},
+					validateStatus: () => true,
 				},
-				httpAgent: config.httpAgent,
-				httpsAgent: config.httpsAgent,
-				proxy: config.axiosProxyConfig,
-				validateStatus: () => true,
-			});
+			);
 
 			// Getting the new API key
 			const newApiKey = AuthService.getApiKeyFromReponse(refreshResponse, config);
@@ -245,16 +245,13 @@ export class AuthService {
 		const cred: AuthCredential = new AuthCredential();
 
 		// Getting the guest token
-		await axios
+		await this._config.instance
 			.post<{
 				/* eslint-disable @typescript-eslint/naming-convention */
 				guest_token: string;
 				/* eslint-enable @typescript-eslint/naming-convention */
 			}>('https://api.twitter.com/1.1/guest/activate.json', undefined, {
 				headers: cred.toHeader(),
-				httpAgent: this._config.httpAgent,
-				httpsAgent: this._config.httpsAgent,
-				proxy: this._config.axiosProxyConfig,
 			})
 			.then((res) => {
 				cred.guestToken = res.data.guest_token;

--- a/src/services/public/FetcherService.ts
+++ b/src/services/public/FetcherService.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosResponse, isAxiosError } from 'axios';
+import { AxiosError, AxiosResponse, isAxiosError } from 'axios';
 import { Cookie } from 'cookiejar';
 import { parseHTML } from 'linkedom';
 import { ClientTransaction } from 'x-client-transaction-id';
@@ -38,9 +38,6 @@ export class FetcherService {
 	/** The service used to handle HTTP and API errors */
 	private readonly _errorHandler: IErrorHandler;
 
-	/** The max wait time for a response. */
-	private readonly _timeout: number;
-
 	/** The config object. */
 	protected readonly config: RettiwtConfig;
 
@@ -52,7 +49,6 @@ export class FetcherService {
 		this.config = config;
 		this._delay = config.delay;
 		this._errorHandler = config.errorHandler ?? new ErrorService();
-		this._timeout = config.timeout ?? 0;
 		this._auth = new AuthService(config);
 	}
 
@@ -126,11 +122,8 @@ export class FetcherService {
 
 	private async _handleXMigration(): Promise<Document> {
 		// Fetch X.com homepage
-		const homePageResponse = await axios.get<string>('https://x.com/home', {
+		const homePageResponse = await this.config.instance.get<string>('https://x.com/home', {
 			headers: this.config.headers,
-			httpAgent: this.config.httpAgent,
-			httpsAgent: this.config.httpsAgent,
-			proxy: this.config.axiosProxyConfig,
 		});
 
 		// Parse HTML using linkedom
@@ -150,11 +143,7 @@ export class FetcherService {
 
 		if (migrationRedirectionUrl) {
 			// Follow redirection URL
-			const redirectResponse = await axios.get<string>(migrationRedirectionUrl[0], {
-				httpAgent: this.config.httpAgent,
-				httpsAgent: this.config.httpsAgent,
-				proxy: this.config.axiosProxyConfig,
-			});
+			const redirectResponse = await this.config.instance.get<string>(migrationRedirectionUrl[0]);
 
 			document = parseHTML(redirectResponse.data).document;
 		}
@@ -181,7 +170,7 @@ export class FetcherService {
 			}
 
 			// Submit form using POST request
-			const formResponse = await axios.request<string>({
+			const formResponse = await this.config.instance.request<string>({
 				method: method,
 				url: url,
 				data: requestPayload,
@@ -193,9 +182,6 @@ export class FetcherService {
 
 					/* eslint-enable @typescript-eslint/naming-convention */
 				},
-				httpAgent: this.config.httpAgent,
-				httpsAgent: this.config.httpsAgent,
-				proxy: this.config.axiosProxyConfig,
 			});
 
 			document = parseHTML(formResponse.data).document;
@@ -307,10 +293,6 @@ export class FetcherService {
 			...cred.toHeader(),
 			...this.config.headers,
 		};
-		config.httpAgent = this.config.httpAgent;
-		config.httpsAgent = this.config.httpsAgent;
-		config.proxy = this.config.axiosProxyConfig;
-		config.timeout = this._timeout;
 
 		// Using retries for error 404
 		do {
@@ -326,7 +308,7 @@ export class FetcherService {
 				await this._wait();
 
 				// Getting the response body
-				const response = await axios<T>(config);
+				const response = await this.config.instance<T>(config);
 				const responseData = response.data;
 
 				// Check for Twitter API errors in response body

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -1,4 +1,4 @@
-import { AxiosProxyConfig, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosProxyConfig, AxiosResponse } from 'axios';
 
 import { IErrorHandler } from './ErrorHandler';
 
@@ -79,23 +79,13 @@ export interface IRettiwtConfig {
 	maxRetries?: number;
 
 	/**
-	 * The Axios adapter to use for making HTTP requests.
+	 * A custom `fetch` implementation to use for making HTTP requests.
 	 *
 	 * @remarks
 	 * <br>
-	 * - If not specified, Axios' default adapter is used.
-	 * - If `fetch` is specified without an `adapter`, the adapter is automatically set to `'fetch'`.
-	 *
-	 * @see {@link https://axios.rest/pages/advanced/fetch-adapter}
-	 */
-	adapter?: NonNullable<AxiosRequestConfig['adapter']>;
-
-	/**
-	 * A custom `fetch` implementation to use with the Axios fetch adapter.
-	 *
-	 * @remarks
-	 * <br>
-	 * - Has no effect unless the `adapter` is set to (or auto-resolves to) `'fetch'`.
+	 * - When specified, the underlying HTTP client switches to a fetch-based transport.
+	 * - Allows injecting a fetch-compatible client (e.g. a browser-impersonation client)
+	 *   to control TLS/HTTP fingerprints or run in environments without Node.js HTTP agents.
 	 *
 	 * @see {@link https://axios.rest/pages/advanced/fetch-adapter}
 	 */

--- a/src/types/RettiwtConfig.ts
+++ b/src/types/RettiwtConfig.ts
@@ -1,4 +1,4 @@
-import { AxiosProxyConfig, AxiosResponse } from 'axios';
+import { AxiosProxyConfig, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { IErrorHandler } from './ErrorHandler';
 
@@ -77,4 +77,27 @@ export interface IRettiwtConfig {
 	 * @remarks Recommended to use a value of 5 combined with a `delay` of 1000 to prevent error 404.
 	 */
 	maxRetries?: number;
+
+	/**
+	 * The Axios adapter to use for making HTTP requests.
+	 *
+	 * @remarks
+	 * <br>
+	 * - If not specified, Axios' default adapter is used.
+	 * - If `fetch` is specified without an `adapter`, the adapter is automatically set to `'fetch'`.
+	 *
+	 * @see {@link https://axios.rest/pages/advanced/fetch-adapter}
+	 */
+	adapter?: NonNullable<AxiosRequestConfig['adapter']>;
+
+	/**
+	 * A custom `fetch` implementation to use with the Axios fetch adapter.
+	 *
+	 * @remarks
+	 * <br>
+	 * - Has no effect unless the `adapter` is set to (or auto-resolves to) `'fetch'`.
+	 *
+	 * @see {@link https://axios.rest/pages/advanced/fetch-adapter}
+	 */
+	fetch?: typeof fetch;
 }


### PR DESCRIPTION
## 🔗 Related Issue

Closes #890

## ❓ Type of Change

- [x] ✨ New feature (adds new functionality)

## 📚 Description

This PR addresses #890 by making Rettiwt-API's HTTP transport layer pluggable, adding two new options to `RettiwtConfig`:

- **`adapter`**: Specifies the Axios adapter to use (`'xhr' | 'http' | 'fetch'`, or a custom adapter function).
- **`fetch`**: Specifies a custom `fetch` implementation (`typeof fetch`) to use with the Axios `fetch` adapter.

Design decisions:
- Added `adapter` and `fetch` to `IRettiwtConfig`. Since `AxiosAdapterConfig` is not exported from the Axios type definitions, it was reproduced as `NonNullable<AxiosRequestConfig['adapter']>`.
- Created a shared private Axios instance (`_instance`) in `RettiwtConfig`, exposed via an `instance` getter. This applies the user-provided `adapter`/`fetch` together with the existing `proxy`/`timeout`/agent settings in one place.
- **Auto-linking**: When `adapter` is unspecified and only `fetch` is provided, `adapter` is automatically set to `'fetch'` so the custom fetch takes effect.
- Switched all 6 Axios call sites (`FetcherService` x4, `AuthService` x2) from the default `axios` to the shared instance (`this.config.instance` / `config.instance`), removing per-request `httpAgent`/`httpsAgent`/`proxy`/`timeout` expansion — now consolidated into the instance defaults.
- The `proxy` setter now recomputes and updates the shared instance's `defaults.httpAgent`/`httpsAgent`/`proxy`, allowing dynamic proxy changes without recreating the instance.
- To avoid transport-specific naming (in anticipation of a future migration from Axios to e.g. `ky`), the instance field/getter use no Axios-derived prefix — simply `_instance` / `instance`.

This enables users to inject browser-impersonation clients (e.g. `impit`, `wreq-js`) as `fetch`, supporting TLS/HTTP fingerprint control and environment-independent transport requirements — fulfilling #890's request to avoid coupling Rettiwt-API to a specific fingerprinting package while allowing any fetch-compatible implementation to be swapped in.

### Verification

Ran live requests via `new Rettiwt({ ... }).user.details('x')` (guest auth):

| config | result | custom fetch calls | behavior |
|---|---|---|---|
| `{}` | OK | 0 | default http adapter works |
| `{adapter:'fetch'}` | OK | 0 | switched to fetch adapter (uses global fetch) |
| `{fetch: wf}` only | OK | 3 | **auto-links to fetch adapter, wrapper function is used** |
| `{adapter:'fetch', fetch: wf}` | OK | 3 | explicit fetch adapter + custom fetch used |
| `{adapter:'http', fetch: wf}` | OK | 0 | **http adapter ignores the custom fetch** |

`build` / `lint:check` (max-warnings 0) / `format:check` all pass.

## 📝 Checklist

- [x] Issue/discussion linked above.
- [x] Documentation updated (if needed) — JSDoc added to type definitions; API doc generation is already configured.
- [x] Code follows project conventions and ESLint rules.
- [x] No sensitive data or credentials are included.