### PR TITLE
ci: add Node.js 24 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                node: [22]
+                node: [22, 24]
 
         steps:
             - name: Checkout
@@ -22,6 +22,8 @@ jobs:
 
             - name: Install node
               uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node }}
 
             - name: Install dependencies
               run: npm install

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CLI tool and an API for fetching data from Twitter for free!
 
 ## Prerequisites
 
-- NodeJS 22
+- NodeJS 22 or 24
 - A working Twitter account (optional)
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"typescript": "^5.7.3"
 			},
 			"engines": {
-				"node": "^22.21.0"
+				"node": "^22.21.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	},
 	"homepage": "https://rishikant181.github.io/Rettiwt-API/",
 	"engines": {
-		"node": "^22.21.0"
+		"node": "^22.21.0 || ^24.0.0"
 	},
 	"devDependencies": {
 		"@types/cookiejar": "^2.1.5",


### PR DESCRIPTION
## Summary
- declare Node.js 24 alongside Node.js 22
- make the existing CI matrix actually select its Node version
- run CI on both Node 22 and 24
- update the prerequisite documentation

## Verification
Executed clean dependency installation, formatting, linting, and TypeScript compilation locally under:

- Node 22.22.1 / npm 10.9.4
- Node 24.19.0 / npm 10.9.8

All checks passed.